### PR TITLE
Add missing properties form_type and eq_id required for go-launch-a-survey.

### DIFF
--- a/data/schema_v1.json
+++ b/data/schema_v1.json
@@ -1,16 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "eq_id": {
-    "type": "string",
-    "description": "Used in combination with the form_type to uniquely identify a questionnaire.",
-    "required": "false"
-  },
-  "form_type": {
-    "type": "string",
-    "description": "Used in combination with the eq_id to uniquely identify a questionnaire.",
-    "required": "false"
-  },
   "definitions": {
     "id": {
       "type": "string",
@@ -253,6 +243,16 @@
     "legal_basis"
   ],
   "properties": {
+    "eq_id": {
+      "type": "string",
+      "description": "Used in combination with the form_type to uniquely identify a questionnaire.",
+      "required": "false"
+    },
+    "form_type": {
+      "type": "string",
+      "description": "Used in combination with the eq_id to uniquely identify a questionnaire.",
+      "required": "false"
+    },
     "mime_type": {
       "type": "string"
     },

--- a/data/schema_v1.json
+++ b/data/schema_v1.json
@@ -245,13 +245,11 @@
   "properties": {
     "eq_id": {
       "type": "string",
-      "description": "Used in combination with the form_type to uniquely identify a questionnaire.",
-      "required": "false"
+      "description": "Used in combination with the form_type to uniquely identify a questionnaire."
     },
     "form_type": {
       "type": "string",
-      "description": "Used in combination with the eq_id to uniquely identify a questionnaire.",
-      "required": "false"
+      "description": "Used in combination with the eq_id to uniquely identify a questionnaire."
     },
     "mime_type": {
       "type": "string"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "json-schema": "^0.2.3",
     "jsonschema": "^1.1.1",
     "lodash": "^4.17.4",
+    "morgan": "^1.9.0",
     "node-fetch": "^1.7.1",
     "nodemon": "^1.11.0",
     "uuid": "^3.0.1"

--- a/src/api/queries.js
+++ b/src/api/queries.js
@@ -9,6 +9,7 @@ exports.getQuestionnaire = gql`
       theme
       legalBasis
       navigation
+      surveyId
       sections {
         id
         title

--- a/src/eq_schema/Questionnaire.js
+++ b/src/eq_schema/Questionnaire.js
@@ -5,13 +5,13 @@ const { last } = require("lodash");
 
 class Questionnaire {
   constructor(authorJson) {
-    const questionnaireId = authorJson.id.toString();
+    const questionnaireId = authorJson.id;
     this.eq_id = questionnaireId;
     this.form_type = questionnaireId;
     this.mime_type = "application/json/ons/eq";
     this.schema_version = "0.0.1";
     this.data_version = "0.0.1";
-    this.survey_id = questionnaireId;
+    this.survey_id = authorJson.surveyId;
     this.title = authorJson.title;
     this.groups = this.buildGroups(authorJson.sections);
     this.theme = authorJson.theme;

--- a/src/eq_schema/Questionnaire.js
+++ b/src/eq_schema/Questionnaire.js
@@ -5,10 +5,13 @@ const { last } = require("lodash");
 
 class Questionnaire {
   constructor(authorJson) {
+    const questionnaireId = authorJson.id.toString();
+    this.eq_id = questionnaireId;
+    this.form_type = questionnaireId;
     this.mime_type = "application/json/ons/eq";
     this.schema_version = "0.0.1";
     this.data_version = "0.0.1";
-    this.survey_id = authorJson.id.toString();
+    this.survey_id = questionnaireId;
     this.title = authorJson.title;
     this.groups = this.buildGroups(authorJson.sections);
     this.theme = authorJson.theme;

--- a/src/eq_schema/Questionnaire.test.js
+++ b/src/eq_schema/Questionnaire.test.js
@@ -54,7 +54,7 @@ describe("Questionnaire", () => {
   });
 
   it("should include form_type and eq_id", () => {
-    const questionnaireId = authorJson.id;
+    const questionnaireId = createQuestionnaireJSON().id;
     expect(questionnaire).toMatchObject({
       eq_id: questionnaireId,
       form_type: questionnaireId

--- a/src/eq_schema/Questionnaire.test.js
+++ b/src/eq_schema/Questionnaire.test.js
@@ -25,9 +25,13 @@ describe("Questionnaire", () => {
       questionnaire
     );
 
-  it("should should build valid runner meta info", () => {
-    const questionnaire = new Questionnaire(createQuestionnaireJSON());
+  let questionnaire;
 
+  beforeEach(() => {
+    questionnaire = new Questionnaire(createQuestionnaireJSON());
+  });
+
+  it("should build valid runner meta info", () => {
     expect(questionnaire).toMatchObject({
       mime_type: "application/json/ons/eq",
       schema_version: "0.0.1",
@@ -46,5 +50,12 @@ describe("Questionnaire", () => {
     const finalPage = last(finalGroup.blocks);
 
     expect(finalPage).toBeInstanceOf(Summary);
+  });
+
+  it("should include form_type and eq_id", () => {
+    expect(questionnaire).toMatchObject({
+      eq_id: "1",
+      form_type: "1"
+    });
   });
 });

--- a/src/eq_schema/Questionnaire.test.js
+++ b/src/eq_schema/Questionnaire.test.js
@@ -8,12 +8,13 @@ describe("Questionnaire", () => {
   const createQuestionnaireJSON = questionnaire =>
     Object.assign(
       {
-        id: 1,
+        id: "1",
         title: "Quarterly Business Survey",
         description: "Quarterly Business Survey",
         theme: "default",
         legalBasis: "StatisticsOfTradeAct",
         navigation: false,
+        surveyId: "0112",
         sections: [
           {
             id: "1",
@@ -36,7 +37,7 @@ describe("Questionnaire", () => {
       mime_type: "application/json/ons/eq",
       schema_version: "0.0.1",
       data_version: "0.0.1",
-      survey_id: "1",
+      survey_id: "0112",
       title: "Quarterly Business Survey",
       theme: "default",
       groups: [expect.any(Group)],

--- a/src/eq_schema/Questionnaire.test.js
+++ b/src/eq_schema/Questionnaire.test.js
@@ -54,9 +54,10 @@ describe("Questionnaire", () => {
   });
 
   it("should include form_type and eq_id", () => {
+    const questionnaireId = authorJson.id;
     expect(questionnaire).toMatchObject({
-      eq_id: "1",
-      form_type: "1"
+      eq_id: questionnaireId,
+      form_type: questionnaireId
     });
   });
 });

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,10 @@
 const express = require("express");
 const app = express();
 
+const morgan = require("morgan");
+
+app.use(morgan("tiny"));
+
 const { getGraphQLApi } = require("./api/createGraphQLApi");
 const Convert = require("./process/Convert");
 const SchemaValidator = require("./validation/SchemaValidator");
@@ -61,6 +65,6 @@ app.get("/publish/:questionnaireId", async (req, res, next) => {
   }
 });
 
-app.listen(PORT, () => {
+app.listen(PORT, "0.0.0.0", () => {
   console.log("Listening on port", PORT); // eslint-disable-line
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -395,6 +395,12 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+basic-auth@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.0.tgz#015db3f353e02e56377755f962742e8981e7bbba"
+  dependencies:
+    safe-buffer "5.1.1"
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
@@ -742,6 +748,12 @@ date-fns@^1.27.2:
 debug@2.6.8, debug@^2.1.1, debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+  dependencies:
+    ms "2.0.0"
+
+debug@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
@@ -2651,6 +2663,16 @@ minimist@^1.1.1, minimist@^1.2.0:
   dependencies:
     minimist "0.0.8"
 
+morgan@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.0.tgz#d01fa6c65859b76fcf31b3cb53a3821a311d8051"
+  dependencies:
+    basic-auth "~2.0.0"
+    debug "2.6.9"
+    depd "~1.1.1"
+    on-finished "~2.3.0"
+    on-headers "~1.0.1"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -2829,6 +2851,10 @@ on-finished@~2.3.0:
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   dependencies:
     ee-first "1.1.1"
+
+on-headers@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
 once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
@@ -3325,7 +3351,7 @@ rxjs@^5.0.0-beta.11:
   dependencies:
     symbol-observable "^1.0.1"
 
-safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -847,16 +847,9 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
+domutils@1.5.1, domutils@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
   dependencies:
     dom-serializer "0"
     domelementtype "1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -745,13 +745,13 @@ date-fns@^1.27.2:
   version "1.28.5"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
 
-debug@2.6.8, debug@^2.1.1, debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
+debug@2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
     ms "2.0.0"
 
-debug@2.6.9:
+debug@2.6.9, debug@^2.1.1, debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -919,7 +919,7 @@ entities@^1.1.1, entities@~1.1.1:
 
 eq-author-graphql-schema@ONSdigital/eq-author-graphql-schema#e5caa74:
   version "1.0.0"
-  resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/e5caa744b1fe0962c21b19448531e64a42174b01"
+  resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/e5caa74"
 
 eq-author-mock-api@ONSdigital/eq-author-mock-api:
   version "1.0.0"


### PR DESCRIPTION
### What is the context of this PR?
This PR adds two additional properties in the resulting JSON produced by Publisher.
These properties, `form_type` and `eq_id` are required in order for the [go-launch-a-survey](https://github.com/ONSdigital/go-launch-a-survey) service to generate valid claims when launching with a URL.
For now, these values can be anything. Currently setting them to be the same as the questionnaire id. This might change over time.

### How to review 
Observe that `form_type` and `eq_id` are present in the resulting JSON.
All tests and checks should pass.
