### PR TITLE
Enable submission during preview.

### DIFF
--- a/src/eq_schema/Questionnaire.js
+++ b/src/eq_schema/Questionnaire.js
@@ -11,7 +11,7 @@ class Questionnaire {
     this.form_type = questionnaireId;
     this.mime_type = "application/json/ons/eq";
     this.schema_version = "0.0.1";
-    this.data_version = "0.0.1";
+    this.data_version = "0.0.2";
     this.survey_id = authorJson.surveyId;
     this.title = authorJson.title;
     this.groups = this.buildGroups(authorJson.sections);

--- a/src/eq_schema/Questionnaire.test.js
+++ b/src/eq_schema/Questionnaire.test.js
@@ -36,7 +36,7 @@ describe("Questionnaire", () => {
     expect(questionnaire).toMatchObject({
       mime_type: "application/json/ons/eq",
       schema_version: "0.0.1",
-      data_version: "0.0.1",
+      data_version: "0.0.2",
       survey_id: "0112",
       title: "Quarterly Business Survey",
       theme: "default",


### PR DESCRIPTION
### What is the context of this PR?
Previously the publisher used data version 0.0.1 which failed upon submission when previewing since it requires q_codes (which Author does not supply).
Changing the data version to 0.0.2 should allow the submission to work. Since 0.0.2 does not require q_codes.

### How to review 
Observed that published schema has a data version of 0.0.2. 
And submission should work when previewing.
