### PR TITLE
Add structured logging to Publisher.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: null
+        base: auto
+
+comment: off

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "apollo-client": "^1.4.2",
     "cheerio": "^1.0.0-rc.2",
     "commonjs-utils": "^0.1.1",
-    "eq-author-graphql-schema": "ONSdigital/eq-author-graphql-schema#e5caa74",
+    "eq-author-graphql-schema": "ONSdigital/eq-author-graphql-schema#a3c5b69",
     "eq-author-mock-api": "ONSdigital/eq-author-mock-api",
     "eslint-config-eq-author": "^1.0.2",
     "express": "^4.15.3",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "eq-author-mock-api": "ONSdigital/eq-author-mock-api",
     "eslint-config-eq-author": "^1.0.2",
     "express": "^4.15.3",
+    "express-pino-logger": "^2.0.0",
     "graphql-tag": "^2.4.0",
     "graphql-tools": "^1.1.0",
     "json-schema": "^0.2.3",
     "jsonschema": "^1.1.1",
     "lodash": "^4.17.4",
-    "morgan": "^1.9.0",
     "node-fetch": "^1.7.1",
     "nodemon": "^1.11.0",
     "uuid": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
   },
   "jest": {
     "coverageDirectory": "./coverage/",
-    "collectCoverage": true
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.js"
+    ]
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,9 @@ const GraphQLApi = getGraphQLApi();
 const app = express();
 app.use(pino());
 
-app.get("/graphql/:questionnaireId", fetchData(GraphQLApi), respondWithData);
+if (process.env.NODE_ENV === "development") {
+  app.get("/graphql/:questionnaireId", fetchData(GraphQLApi), respondWithData);
+}
 
 app.get(
   "/publish/:questionnaireId",

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,9 @@
 const express = require("express");
 const app = express();
 
-const morgan = require("morgan");
+const pino = require("express-pino-logger")();
 
-app.use(morgan("tiny"));
+app.use(pino);
 
 const { getGraphQLApi } = require("./api/createGraphQLApi");
 const Convert = require("./process/Convert");
@@ -39,6 +39,7 @@ app.get("/graphql/:questionnaireId", async (req, res, next) => {
 
     res.json(result);
   } catch (err) {
+    req.log.error(err);
     res.json({
       result: "error",
       message: err.message,
@@ -57,6 +58,7 @@ app.get("/publish/:questionnaireId", async (req, res, next) => {
 
     res.json(converter.convert(result.data));
   } catch (err) {
+    req.log.error(err);
     res.json({
       result: "error",
       message: err.message,

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,0 +1,9 @@
+/* eslint-disable no-unused-vars */
+const ValidationError = require("../validation/ValidationError");
+
+module.exports = function errorHandler(err, req, res, next) {
+  req.log.error(err);
+
+  const statusCode = err instanceof ValidationError ? 422 : 500;
+  res.status(statusCode).json(err);
+};

--- a/src/middleware/errorHandler.test.js
+++ b/src/middleware/errorHandler.test.js
@@ -1,0 +1,55 @@
+const errorHandler = require("./errorHandler");
+const ValidationError = require("../validation/ValidationError");
+
+describe("errorHandler", () => {
+  let res, req, next;
+
+  beforeEach(() => {
+    res = {};
+    res.status = jest.fn(() => res);
+    res.json = jest.fn(() => res);
+
+    req = {
+      log: {
+        error: jest.fn()
+      }
+    };
+
+    next = jest.fn();
+  });
+
+  it("should log all errors", () => {
+    const error = new Error("test error");
+    errorHandler(error, req, res, next);
+
+    expect(req.log.error).toHaveBeenCalledWith(error);
+  });
+
+  it("should respond with 422 status if ValidationError", () => {
+    const error = new ValidationError("test error");
+    errorHandler(error, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it("should respond with 500 status if not ValidationError", () => {
+    const error = new Error("test error");
+    errorHandler(error, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  it("should respond with JSON of error", () => {
+    const error = new Error("test error");
+    errorHandler(error, req, res, next);
+
+    expect(res.json).toHaveBeenCalledWith(error);
+  });
+
+  it("should not pass control to next middleware", () => {
+    const error = new Error("test error");
+    errorHandler(error, req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/src/middleware/fetchData.js
+++ b/src/middleware/fetchData.js
@@ -1,0 +1,22 @@
+const { get } = require("lodash");
+
+const fetchData = API => async (req, res, next) => {
+  let result;
+
+  try {
+    result = await API.getAuthorData(req.params.questionnaireId);
+  } catch (err) {
+    return next(err);
+  }
+
+  const questionnaire = get(result, "data.questionnaire");
+
+  if (!questionnaire) {
+    return res.sendStatus(404);
+  }
+
+  res.locals.questionnaire = questionnaire;
+  return next();
+};
+
+module.exports = fetchData;

--- a/src/middleware/fetchData.test.js
+++ b/src/middleware/fetchData.test.js
@@ -1,0 +1,63 @@
+const fetchData = require("./fetchData");
+
+describe("fetchData", () => {
+  let res, req, next, API, fetcher;
+
+  beforeEach(() => {
+    res = {
+      locals: {},
+      sendStatus: jest.fn()
+    };
+
+    req = {
+      params: {
+        questionnaireId: "123"
+      }
+    };
+
+    API = {
+      getAuthorData: jest.fn()
+    };
+
+    next = jest.fn();
+
+    fetcher = fetchData(API);
+  });
+
+  it("should request data from API", () => {
+    fetcher(req, res, next);
+
+    expect(API.getAuthorData).toHaveBeenCalledWith(req.params.questionnaireId);
+  });
+
+  it("should pass error to next middleware if API errors", () => {
+    const error = new Error("oops");
+    API.getAuthorData.mockImplementation(() => {
+      throw error;
+    });
+
+    fetcher(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(error);
+  });
+
+  it("should respond with 404 if no questionnaire returned", async () => {
+    API.getAuthorData.mockImplementation(() => null);
+    await fetcher(req, res, next);
+
+    expect(res.sendStatus).toHaveBeenCalledWith(404);
+  });
+
+  it("should assign questionnaire for next middleware", async () => {
+    const questionnaire = { id: "123" };
+
+    API.getAuthorData.mockImplementation(() => ({
+      data: { questionnaire }
+    }));
+
+    await fetcher(req, res, next);
+
+    expect(res.locals.questionnaire).toBe(questionnaire);
+    expect(next).toHaveBeenCalledWith();
+  });
+});

--- a/src/middleware/respondWithData.js
+++ b/src/middleware/respondWithData.js
@@ -1,0 +1,3 @@
+module.exports = function respondWithData(req, res) {
+  res.json(res.locals.questionnaire);
+};

--- a/src/middleware/respondWithData.test.js
+++ b/src/middleware/respondWithData.test.js
@@ -1,0 +1,21 @@
+const respondWithData = require("./respondWithData");
+
+describe("fetchData", () => {
+  let res, req;
+
+  beforeEach(() => {
+    res = {
+      locals: {
+        questionnaire: { id: "123" }
+      },
+      json: jest.fn()
+    };
+
+    req = {};
+  });
+
+  it("respond with local data from response", () => {
+    respondWithData(req, res);
+    expect(res.json).toHaveBeenCalledWith(res.locals.questionnaire);
+  });
+});

--- a/src/middleware/schemaConverter.js
+++ b/src/middleware/schemaConverter.js
@@ -1,0 +1,8 @@
+module.exports = converter => (req, res, next) => {
+  try {
+    res.locals.questionnaire = converter.convert(res.locals.questionnaire);
+    next();
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/middleware/schemaConverter.test.js
+++ b/src/middleware/schemaConverter.test.js
@@ -1,0 +1,53 @@
+const schemaConverter = require("./schemaConverter");
+
+describe("schemaConverter", () => {
+  let res, req, next, converter, middleware, questionnaire;
+
+  beforeEach(() => {
+    questionnaire = { id: "123" };
+
+    res = {
+      locals: { questionnaire }
+    };
+
+    converter = {
+      convert: jest.fn()
+    };
+
+    req = {};
+    next = jest.fn();
+
+    middleware = schemaConverter(converter);
+  });
+
+  it("should convert data", () => {
+    middleware(req, res, next);
+
+    expect(converter.convert).toHaveBeenCalledWith(questionnaire);
+  });
+
+  describe("when successful", () => {
+    it("should assign converted questionnaire for next middleware", () => {
+      const converted = { title: "i've been converted" };
+      converter.convert.mockImplementation(() => converted);
+
+      middleware(req, res, next);
+
+      expect(res.locals.questionnaire).toBe(converted);
+      expect(next).toHaveBeenCalledWith();
+    });
+  });
+
+  describe("when error occurs", () => {
+    it("should pass error to next middleware", () => {
+      const error = new Error("conversion error");
+      converter.convert.mockImplementation(() => {
+        throw error;
+      });
+
+      middleware(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(error);
+    });
+  });
+});

--- a/src/process/Convert.js
+++ b/src/process/Convert.js
@@ -10,7 +10,7 @@ class Convert {
   }
 
   convert(authorJson) {
-    const output = new Questionnaire(authorJson.questionnaire);
+    const output = new Questionnaire(authorJson);
     const validation = this.schemaValidator.validate(output);
 
     if (!validation.valid) {

--- a/src/process/Convert.test.js
+++ b/src/process/Convert.test.js
@@ -34,7 +34,7 @@ describe("Convert", () => {
 
       const result = await graphQLApi.getAuthorData(2);
       const convert = new Convert(mockSchemaValidator);
-      convert.convert(result.data);
+      convert.convert(result.data.questionnaire);
 
       expect(mockSchemaValidator.validate).toBeCalled();
     });
@@ -50,7 +50,7 @@ describe("Convert", () => {
 
       const result = await graphQLApi.getAuthorData(1);
 
-      expect(() => convert.convert(result.data)).toThrow();
+      expect(() => convert.convert(result.data.questionnaire)).toThrow();
     });
   });
 });

--- a/src/validation/ValidationError.js
+++ b/src/validation/ValidationError.js
@@ -1,5 +1,4 @@
 class ValidationError extends Error {
-
   constructor(message, validation) {
     super(message);
     this.validation = validation;
@@ -8,7 +7,6 @@ class ValidationError extends Error {
   toString() {
     return this.message + "\n" + JSON.stringify(this.validation);
   }
-
 }
 
 module.exports = ValidationError;

--- a/src/validation/createSchemaValidator.js
+++ b/src/validation/createSchemaValidator.js
@@ -1,0 +1,19 @@
+const SchemaValidator = require("../validation/SchemaValidator");
+
+const EQ_RUNNER_MAIN_SCHEMA = require("../../data/schema_v1.json");
+const EQ_RUNNER_UNITS_SCHEMA = require("../../data/units.json");
+const EQ_RUNNER_CURRENCY_SCHEMA = require("../../data/currencies.json");
+
+const createSchemaValidator = () =>
+  new SchemaValidator(EQ_RUNNER_MAIN_SCHEMA, [
+    {
+      uri: "/units.json",
+      schema: EQ_RUNNER_UNITS_SCHEMA
+    },
+    {
+      uri: "/currencies.json",
+      schema: EQ_RUNNER_CURRENCY_SCHEMA
+    }
+  ]);
+
+module.exports = createSchemaValidator;

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,7 +92,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0:
+ansi-styles@^3.0.0, ansi-styles@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -395,12 +395,6 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-basic-auth@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.0.tgz#015db3f353e02e56377755f962742e8981e7bbba"
-  dependencies:
-    safe-buffer "5.1.1"
-
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
@@ -506,6 +500,14 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.2.0.tgz#477b3bf2f9b8fd5ca9e429747e37f724ee7af240"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
 
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
@@ -751,7 +753,7 @@ debug@2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@2.6.9, debug@^2.1.1, debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
+debug@^2.1.1, debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -907,7 +909,7 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-end-of-stream@^1.0.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.0.tgz#7a90d833efda6cfa6eac0f4949dbb0fad3a63206"
   dependencies:
@@ -1272,6 +1274,12 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
+express-pino-logger@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/express-pino-logger/-/express-pino-logger-2.0.0.tgz#e2b1046a8e9a9fe65d4e7fcbe57115e28df076a1"
+  dependencies:
+    pino-http "^2.0.0"
+
 express@^4.15.3:
   version "4.15.4"
   resolved "https://registry.yarnpkg.com/express/-/express-4.15.4.tgz#032e2253489cf8fce02666beca3d11ed7a2daed1"
@@ -1319,9 +1327,17 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
 
+fast-json-parse@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+fast-safe-stringify@^1.0.8, fast-safe-stringify@^1.1.11:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-1.2.0.tgz#ebd42666fd18fe4f2ba4f0d295065f3f85cade96"
 
 fb-watchman@^1.8.0:
   version "1.9.2"
@@ -1403,6 +1419,10 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
+
+flatstr@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.5.tgz#5b451b08cbd48e2eac54a2bbe0bf46165aa14be3"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -1630,6 +1650,10 @@ has-ansi@^2.0.0:
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -2663,16 +2687,6 @@ minimist@^1.1.1, minimist@^1.2.0:
   dependencies:
     minimist "0.0.8"
 
-morgan@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.0.tgz#d01fa6c65859b76fcf31b3cb53a3821a311d8051"
-  dependencies:
-    basic-auth "~2.0.0"
-    debug "2.6.9"
-    depd "~1.1.1"
-    on-finished "~2.3.0"
-    on-headers "~1.0.1"
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -2852,11 +2866,7 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-on-headers@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
-
-once@^1.3.0, once@^1.3.3, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -3036,6 +3046,24 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pino-http@^2.0.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/pino-http/-/pino-http-2.6.2.tgz#aedb71b08d15bc69d959870bafa6b7780103274f"
+  dependencies:
+    pino "^4.0.2"
+
+pino@^4.0.2:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-4.8.0.tgz#ffe37684233ebf33ffa58140d7fb5c1f7e170ecd"
+  dependencies:
+    chalk "^2.0.1"
+    fast-json-parse "^1.0.0"
+    fast-safe-stringify "^1.1.11"
+    flatstr "^1.0.4"
+    pump "^1.0.2"
+    quick-format-unescaped "^1.1.1"
+    split2 "^2.0.1"
+
 pkg-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
@@ -3102,6 +3130,13 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
+pump@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.2.tgz#3b3ee6512f94f0e575538c17995f9f16990a5d51"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -3113,6 +3148,12 @@ qs@6.5.0:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+quick-format-unescaped@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-1.1.1.tgz#e77555ef3e66e105d4039e13ef79201284fee916"
+  dependencies:
+    fast-safe-stringify "^1.0.8"
 
 randomatic@^1.1.3:
   version "1.1.7"
@@ -3171,7 +3212,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
+readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -3351,7 +3392,7 @@ rxjs@^5.0.0-beta.11:
   dependencies:
     symbol-observable "^1.0.1"
 
-safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
@@ -3500,6 +3541,12 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
+split2@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
+  dependencies:
+    through2 "^2.0.2"
+
 split@0.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
@@ -3621,6 +3668,12 @@ supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
+supports-color@^4.0.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  dependencies:
+    has-flag "^2.0.0"
+
 symbol-observable@^1.0.1, symbol-observable@^1.0.2, symbol-observable@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
@@ -3678,6 +3731,13 @@ text-table@~0.2.0:
 throat@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"
+
+through2@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
+  dependencies:
+    readable-stream "^2.1.5"
+    xtend "~4.0.1"
 
 through@2, through@^2.3.6, through@~2.3, through@~2.3.1:
   version "2.3.8"
@@ -3933,7 +3993,7 @@ xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 
-xtend@^4.0.0, xtend@^4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -917,9 +917,9 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-eq-author-graphql-schema@ONSdigital/eq-author-graphql-schema#e5caa74:
-  version "1.0.0"
-  resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/e5caa74"
+eq-author-graphql-schema@ONSdigital/eq-author-graphql-schema#a3c5b69:
+  version "0.1.1"
+  resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/a3c5b6982d2ec4c57f1ea6311bae7f8e35f12c8e"
 
 eq-author-mock-api@ONSdigital/eq-author-mock-api:
   version "1.0.0"


### PR DESCRIPTION
### What is the context of this PR?
Adds structured (JSON) logging to the Publisher.
Removes the basic HTTP logging (morgan) and replaces it with `express-pino-logger`.
Logs errors before returning the response.

### How to review 
Observe that Publisher produces JSON structured HTTP logs.
Observe that errors are logged if there's a problem during publishing/conversion.
