### PR TITLE
add support for DateRange answers

### DIFF
--- a/src/eq_schema/Question.js
+++ b/src/eq_schema/Question.js
@@ -1,17 +1,45 @@
 const Answer = require("./Answer");
 const { getInnerHTML, parseGuidance } = require("../utils/HTMLUtils");
+const { find } = require("lodash");
+
+const findDateRange = question => find(question.answers, { type: "DateRange" });
 
 class Question {
   constructor(question) {
     this.id = "question-" + question.id.toString();
     this.title = getInnerHTML(question.title);
     this.guidance = parseGuidance(question.guidance);
-    this.type = "General";
-    this.answers = this.buildAnswers(question.answers);
+
+    const dateRange = findDateRange(question);
+
+    if (dateRange) {
+      this.type = "DateRange";
+      this.answers = this.buildDateRangeAnswers(dateRange);
+    } else {
+      this.type = "General";
+      this.answers = this.buildAnswers(question.answers);
+    }
   }
 
   buildAnswers(answers) {
     return answers.map(answer => new Answer(answer));
+  }
+
+  buildDateRangeAnswers({ id }) {
+    return [
+      new Answer({
+        label: "Period from",
+        type: "Date",
+        id: `${id}-from`,
+        mandatory: true
+      }),
+      new Answer({
+        label: "Period to",
+        type: "Date",
+        id: `${id}-to`,
+        mandatory: true
+      })
+    ];
   }
 }
 

--- a/src/eq_schema/Question.test.js
+++ b/src/eq_schema/Question.test.js
@@ -56,4 +56,43 @@ describe("Question", () => {
       });
     });
   });
+
+  describe("DateRange", () => {
+    it("should convert Author DateRange to Runner-compatible format", () => {
+      const answers = [{ type: "DateRange", id: "1" }];
+      const question = new Question(createQuestionJSON({ answers }));
+
+      expect(question).toMatchObject({
+        type: "DateRange",
+        answers: [
+          {
+            label: "Period from",
+            type: "Date",
+            id: "answer-1-from",
+            mandatory: true
+          },
+          {
+            label: "Period to",
+            type: "Date",
+            id: "answer-1-to",
+            mandatory: true
+          }
+        ]
+      });
+    });
+
+    it("discards any other answers if DateRange used", () => {
+      const answers = [
+        { type: "DateRange", id: "1" },
+        { type: "TextField", id: "2" }
+      ];
+      const question = new Question(createQuestionJSON({ answers }));
+
+      expect(question.answers).not.toContainEqual(
+        expect.objectContaining({
+          type: "TextField"
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
### What is the context of this PR?
Add support for date range answer types.

Author will allow users to mix DateRange answer types with other answers (this is not supported by runner and causes errors). We will eventually restrict this in the UI. In the meanwhile, I have added logic here to drop all non-DateRange answers from a page when a DateRange is found.

### How to review 
Review code, run tests, test previewing with author