### PR TITLE
Support piping

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "apollo-client": "^1.4.2",
     "cheerio": "^1.0.0-rc.2",
     "commonjs-utils": "^0.1.1",
-    "eq-author-graphql-schema": "ONSdigital/eq-author-graphql-schema#a3c5b69",
+    "eq-author-graphql-schema": "0.3.0",
     "eq-author-mock-api": "ONSdigital/eq-author-mock-api",
     "eslint-config-eq-author": "^1.0.2",
     "express": "^4.15.3",

--- a/src/eq_schema/Answer.js
+++ b/src/eq_schema/Answer.js
@@ -2,7 +2,7 @@
 
 class Answer {
   constructor(answer) {
-    this.id = "answer-" + answer.id.toString();
+    this.id = this.alias = "answer-" + answer.id;
     this.mandatory = answer.mandatory;
     this.type = answer.type;
     this.label = answer.label;

--- a/src/eq_schema/Answer.test.js
+++ b/src/eq_schema/Answer.test.js
@@ -21,6 +21,7 @@ describe("Answer", () => {
 
     expect(answer).toMatchObject({
       id: "answer-1",
+      alias: "answer-1",
       type: "PositiveInteger",
       mandatory: false,
       description: "This is a description"

--- a/src/eq_schema/Block.js
+++ b/src/eq_schema/Block.js
@@ -1,12 +1,18 @@
 const Question = require("./Question");
 const { get } = require("lodash");
 const { getInnerHTML } = require("../utils/HTMLUtils");
+const convertPipes = require("../utils/convertPipes");
+
+const pageTypeMappings = {
+  QuestionPage: "Questionnaire",
+  InterstitialPage: "Interstitial"
+};
 
 class Block {
   constructor(title, page) {
     this.id = "block-" + page.id.toString();
     this.title = getInnerHTML(title);
-    this.description = getInnerHTML(page.description);
+    this.description = getInnerHTML(convertPipes(page.description));
     this.type = this.convertPageType(page.pageType);
     this.questions = this.buildQuestions(page);
   }
@@ -16,12 +22,7 @@ class Block {
   }
 
   convertPageType(type) {
-    const mappings = {
-      QuestionPage: "Questionnaire",
-      InterstitialPage: "Interstitial"
-    };
-
-    return get(mappings, type, type);
+    return get(pageTypeMappings, type, type);
   }
 }
 

--- a/src/eq_schema/Block.test.js
+++ b/src/eq_schema/Block.test.js
@@ -61,4 +61,20 @@ describe("Block", () => {
       expect(block.type).toEqual("Interstitial");
     });
   });
+
+  describe("piping", () => {
+    const createPipe = (
+      { id = "123", type = "TextField", text = "foo" } = {}
+    ) =>
+      `<span data-pipe="answers" data-id="${id}" data-type="${type}">${text}</span>`;
+
+    it("should handle piped values in description", () => {
+      const block = new Block(
+        "section title",
+        createBlockJSON({ description: `<p>${createPipe()}</p>` })
+      );
+
+      expect(block.description).toEqual("{{answers.answer-123}}");
+    });
+  });
 });

--- a/src/eq_schema/Question.js
+++ b/src/eq_schema/Question.js
@@ -1,14 +1,18 @@
 const Answer = require("./Answer");
 const { getInnerHTML, parseGuidance } = require("../utils/HTMLUtils");
-const { find } = require("lodash");
+const { find, get, flow } = require("lodash/fp");
+const convertPipes = require("../utils/convertPipes");
 
-const findDateRange = question => find(question.answers, { type: "DateRange" });
+const findDateRange = flow(get("answers"), find({ type: "DateRange" }));
+
+const processTitle = flow(convertPipes, getInnerHTML);
+const processGuidance = flow(convertPipes, parseGuidance);
 
 class Question {
   constructor(question) {
-    this.id = "question-" + question.id.toString();
-    this.title = getInnerHTML(question.title);
-    this.guidance = parseGuidance(question.guidance);
+    this.id = "question-" + question.id;
+    this.title = processTitle(question.title);
+    this.guidance = processGuidance(question.guidance);
 
     const dateRange = findDateRange(question);
 

--- a/src/eq_schema/Question.test.js
+++ b/src/eq_schema/Question.test.js
@@ -95,4 +95,33 @@ describe("Question", () => {
       );
     });
   });
+
+  describe("piping", () => {
+    const createPipe = (
+      { id = "123", type = "TextField", text = "foo" } = {}
+    ) =>
+      `<span data-pipe="answers" data-id="${id}" data-type="${type}">${text}</span>`;
+
+    it("should handle piped values in title", () => {
+      const question = new Question(
+        createQuestionJSON({
+          title: createPipe()
+        })
+      );
+
+      expect(question.title).toEqual("{{answers.answer-123}}");
+    });
+
+    it("should handle piped values in guidance", () => {
+      const question = new Question(
+        createQuestionJSON({
+          guidance: `<h2>${createPipe()}</h2>`
+        })
+      );
+
+      expect(question.guidance.content[0]).toEqual({
+        title: "{{answers.answer-123}}"
+      });
+    });
+  });
 });

--- a/src/utils/convertPipes.js
+++ b/src/utils/convertPipes.js
@@ -1,0 +1,36 @@
+const cheerio = require("cheerio");
+
+const filterMap = {
+  Number: "format_number",
+  Currency: "format_currency",
+  Date: "format_date"
+};
+
+const convertElementToPipe = $elem => {
+  const { pipe, id, type } = $elem.data();
+  const filter = filterMap[type];
+  let inner = `${pipe}.answer-${id}`;
+
+  if (filter) {
+    inner += `|${filter}`;
+  }
+
+  return `{{${inner}}}`;
+};
+
+const parseHTML = (html = "") => {
+  return cheerio.load(html)("body");
+};
+
+const convertPipes = html => {
+  const $ = parseHTML(html);
+
+  $.find("[data-pipe]").each((i, elem) => {
+    const $elem = cheerio(elem);
+    $elem.replaceWith(convertElementToPipe($elem));
+  });
+
+  return $.html();
+};
+
+module.exports = convertPipes;

--- a/src/utils/convertPipes.test.js
+++ b/src/utils/convertPipes.test.js
@@ -1,0 +1,60 @@
+const convertPipes = require("../utils/convertPipes");
+
+const createPipe = ({ id = "123", type = "TextField", text = "foo" } = {}) =>
+  `<span data-pipe="answers" data-id="${id}" data-type="${type}">${text}</span>`;
+
+describe("convertPipes", () => {
+  it("should handle empty strings", () => {
+    expect(convertPipes("")).toEqual("");
+  });
+
+  it("should handle empty html tags", () => {
+    expect(convertPipes("<p></p>")).toEqual("<p></p>");
+  });
+
+  it("should convert relevant elements to pipe format", () => {
+    const html = createPipe();
+    expect(convertPipes(html)).toEqual("{{answers.answer-123}}");
+  });
+
+  it("should handle multiple piped values", () => {
+    const pipe1 = createPipe();
+    const pipe2 = createPipe({ id: "456", text: "bar" });
+    const html = `${pipe1}${pipe2}`;
+
+    expect(convertPipes(html)).toEqual(
+      "{{answers.answer-123}}{{answers.answer-456}}"
+    );
+  });
+
+  it("should handle piped values amongst regular text", () => {
+    const pipe1 = createPipe();
+    const pipe2 = createPipe({ id: "456", text: "bar" });
+    const html = `hello ${pipe1}${pipe2} world`;
+
+    expect(convertPipes(html)).toEqual(
+      "hello {{answers.answer-123}}{{answers.answer-456}} world"
+    );
+  });
+
+  describe("formatting", () => {
+    it("should format Date answers with `format_date`", () => {
+      const html = createPipe({ id: "123", type: "Date" });
+      expect(convertPipes(html)).toEqual("{{answers.answer-123|format_date}}");
+    });
+
+    it("should format Currency answers with `format_currency`", () => {
+      const html = createPipe({ id: "123", type: "Currency" });
+      expect(convertPipes(html)).toEqual(
+        "{{answers.answer-123|format_currency}}"
+      );
+    });
+
+    it("should format Number answers with `format_number`", () => {
+      const html = createPipe({ id: "123", type: "Number" });
+      expect(convertPipes(html)).toEqual(
+        "{{answers.answer-123|format_number}}"
+      );
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -919,9 +919,9 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-eq-author-graphql-schema@ONSdigital/eq-author-graphql-schema#a3c5b69:
-  version "0.1.1"
-  resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/a3c5b6982d2ec4c57f1ea6311bae7f8e35f12c8e"
+eq-author-graphql-schema@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.3.0.tgz#6821c3785275c29a7e358abde42305c5dda26930"
 
 eq-author-mock-api@ONSdigital/eq-author-mock-api:
   version "1.0.0"


### PR DESCRIPTION
### What is the context of this PR?
Adds support for piped values coming from author

* Author uses a different format to runner so that we have more flexibility/room for change in future
* Adds functions for processing HTML to convert from author format to runner format
* Integrates conversion step into Question title and guidance and Block description

### How to review 
Run tests. Review code. You can test conversion by either manually entering piped value into your DB (format is `<span data-pipe="answers" data-id="[an answer id]" data-type="[the answer type]">[Answer test]</span>`), or testing with the [WIP author branch](https://github.com/ONSdigital/eq-author/tree/draft-piping)
