### PR TITLE
Set codecov target coverage to 85%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: auto
+        target: 85%
         threshold: null
         base: auto
 


### PR DESCRIPTION
### What is the context of this PR?
eq-publisher is currently failing on master due to codecov coverage failure.
This failure is result of the coverage being fixed by a prior commit. Previously it was erroneously reporting 100% coverage.
This PR sets the coverage target to 85% as a baseline.

### How to review 
Codecov check should pass.
