### PR TITLE
Fixes missing description text under checkbox/radio options.

### DIFF
--- a/data/schema_v1.json
+++ b/data/schema_v1.json
@@ -518,6 +518,9 @@
                                   "value": {
                                     "type": "string"
                                   },
+                                  "description": {
+                                    "type": "string"
+                                  },
                                   "q_code": {
                                     "$ref": "#/definitions/q_code"
                                   },

--- a/src/eq_schema/Answer.js
+++ b/src/eq_schema/Answer.js
@@ -17,10 +17,11 @@ class Answer {
     }
   }
 
-  buildOption({ label, childAnswerId }) {
+  buildOption({ label, childAnswerId, description }) {
     const option = {
       label,
-      value: label
+      value: label,
+      description
     };
 
     if (childAnswerId) {

--- a/src/eq_schema/Answer.test.js
+++ b/src/eq_schema/Answer.test.js
@@ -47,12 +47,14 @@ describe("Answer", () => {
             {
               id: 1,
               label: "Option one",
-              childAnswerId: "foo"
+              childAnswerId: "foo",
+              description: "A short description"
             },
             {
               id: 2,
               label: "Option two",
-              childAnswerId: "bar"
+              childAnswerId: "bar",
+              description: "Another description"
             }
           ]
         })
@@ -62,12 +64,14 @@ describe("Answer", () => {
         {
           label: "Option one",
           value: "Option one",
-          child_answer_id: "foo"
+          child_answer_id: "foo",
+          description: "A short description"
         },
         {
           label: "Option two",
           value: "Option two",
-          child_answer_id: "bar"
+          child_answer_id: "bar",
+          description: "Another description"
         }
       ]);
     });


### PR DESCRIPTION
### What is the context of this PR?
Fixes [#257](https://github.com/ONSdigital/eq-author/issues/257).
Prior to this PR, optional description text entered for an Option in either Checkbox or Radio answer types were not included in the Published schema (and not visible in Runner preview).
This PR fixes this and includes the description text in the published output JSON.

### How to review 
The description text should appear for Checkbox/Radio options when previewing the questionnaire.
