### PR TITLE
Fixes #35. Error when null answer option description.

### DIFF
--- a/src/eq_schema/Answer.js
+++ b/src/eq_schema/Answer.js
@@ -20,9 +20,12 @@ class Answer {
   buildOption({ label, childAnswerId, description }) {
     const option = {
       label,
-      value: label,
-      description
+      value: label
     };
+
+    if (description) {
+      option.description = description;
+    }
 
     if (childAnswerId) {
       option.child_answer_id = childAnswerId;

--- a/src/eq_schema/Answer.test.js
+++ b/src/eq_schema/Answer.test.js
@@ -103,4 +103,39 @@ describe("Answer", () => {
       expect(answer.options).toEqual([]);
     });
   });
+
+  it("should omit option description if null value provided", () => {
+    const answer = new Answer(
+      createAnswerJSON({
+        type: "Radio",
+        options: [
+          {
+            id: 1,
+            label: "Option one",
+            childAnswerId: "foo",
+            description: null
+          },
+          {
+            id: 2,
+            label: "Option two",
+            childAnswerId: "bar",
+            description: null
+          }
+        ]
+      })
+    );
+
+    expect(answer.options).toEqual([
+      {
+        label: "Option one",
+        value: "Option one",
+        child_answer_id: "foo"
+      },
+      {
+        label: "Option two",
+        value: "Option two",
+        child_answer_id: "bar"
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
### What is the context of this PR?
Fixes #35.

Should now handle null values in the `option.description` field.

### How to review 
Error should no longer be observed. Description will only appear in the outputted JSON if value provided.
