### PR TITLE
Fixes broken preview when running with eq-compose.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,8 +29,7 @@ app.get(
 app.use(errorHandler);
 
 const PORT = process.env.PORT || 9000;
-const HOSTNAME = process.env.HOSTNAME || "0.0.0.0";
 
-app.listen(PORT, HOSTNAME, () => {
+app.listen(PORT, "0.0.0.0", () => {
   console.log("Listening on port", PORT); // eslint-disable-line
 });


### PR DESCRIPTION
### What is the context of this PR?
Fixes https://github.com/ONSdigital/eq-compose/issues/6.
The publisher application was not binding to address 0.0.0.0 when running
using docker compose, since the HOSTNAME environment variable was being
set by the docker engine and resolving to the container name.

This resulted in connection refused errors being reported by publisher
when the survey launcher attempted to request the survey JSON.

This fix, changes publisher to always bind to 0.0.0.0.

### How to review 
Should be able to preview questionnaires when running eq-compose.
