### PR TITLE
Switch publisher to build and run on node 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "7"
+  - "8"
 
 before_install:
   - yarn add codecov

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7
+FROM node:8
 MAINTAINER eq.team@ons.gov.uk
 
 EXPOSE 9000


### PR DESCRIPTION
### What is the context of this PR?
Changed travis config so that Publisher is built in node LTS container (should be Node 8).
Changed Dockerfile configuration so that publisher runs in Node 8 environment.

### How to review 
All tests and checks should pass. Build should succeed.
Visual inspection of travis build log to confirm Node 8 runtime is being used.
Pull down the branch docker image/ docker inspect to ensure that node 8 is used.
Run the newly built docker image, should work as expected.
