### PR TITLE
Enable attaching a debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,28 @@ Since the API is still under active development, there are only two routes at pr
 | ------------- | ------------- |
 | [/graphql/:questionaireId](http://localhost:9000/graphql/1)  | Demonstrates the JSON that is output by the Author API.  |
 | [/publish/:questionaireId](http://localhost:9000/publish/1)  | Demonstrates the published EQ JSON.  |
+
+
+## Debugging
+
+If you have started the app with `docker-compose` then you can attach a debugger. If you use vscode, this is the `launch.json` configuration you must use:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach to Container",
+      "type": "node",
+      "request": "attach",
+      "port": 5858,
+      "address": "localhost",
+      "restart": true,
+      "sourceMaps": false,
+      "localRoot": "${workspaceRoot}",
+      "remoteRoot": "/app",
+      "protocol": "inspector"
+    }
+  ]
+}
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,14 @@ services:
       - EQ_AUTHOR_API_URL=http://docker.for.mac.host.internal:4000/graphql
     ports:
       - "9000:9000"
+      - "5858:5858" # open port for debugging
     volumes:
       - .:/app
     depends_on:
       - eq-schema-validator
+    entrypoint:
+      - yarn
+      - start:dev
 
   eq-schema-validator:
     image: onsdigital/eq-schema-validator

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "start": "nodemon",
-    "start:dev": "nodemon --inspect",
+    "start:dev": "nodemon --inspect=0.0.0.0:5858",
     "test": "jest",
     "lint": "eslint .",
     "precommit": "lint-staged"


### PR DESCRIPTION
### What is the context of this PR?
Since switching to docker-compose, debugging was not possible. This change starts the app with the `--inspect` flag, and opens the debug port so that debuggers can be attached

### How to review 
Ensure everything looks good. Use this debugger config for vscode to test it out:

```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "name": "Attach to Container",
      "type": "node",
      "request": "attach",
      "port": 5858,
      "address": "localhost",
      "restart": true,
      "sourceMaps": false,
      "localRoot": "${workspaceRoot}",
      "remoteRoot": "/app",
      "protocol": "inspector"
    }
  ]
}
```