### PR TITLE
Promote section in schema

### DIFF
--- a/src/eq_schema/Answer.js
+++ b/src/eq_schema/Answer.js
@@ -29,7 +29,7 @@ class Answer {
     }
 
     if (childAnswerId) {
-      option.child_answer_id = childAnswerId;
+      option.child_answer_id = childAnswerId.toString();
     }
 
     return option;

--- a/src/eq_schema/Group.js
+++ b/src/eq_schema/Group.js
@@ -2,13 +2,13 @@ const Block = require("./Block");
 const { getInnerHTML } = require("../utils/HTMLUtils");
 
 class Group {
-  constructor(section) {
-    this.id = `group-${section.id}`;
-    this.title = getInnerHTML(section.title);
-    this.blocks = this.buildBlocks(this.title, section);
+  constructor(id, title, description, pages) {
+    this.id = `group-${id}`;
+    this.title = getInnerHTML(title);
+    this.blocks = this.buildBlocks(this.title, description, pages);
   }
 
-  buildBlocks(title, { description, pages }) {
+  buildBlocks(title, description, pages) {
     return pages.map(page => new Block(title, description, page));
   }
 }

--- a/src/eq_schema/Group.test.js
+++ b/src/eq_schema/Group.test.js
@@ -18,7 +18,13 @@ describe("Group", () => {
     );
 
   it("should build valid runner Group from Author section", () => {
-    const group = new Group(createGroupJSON());
+    let groupJSON = createGroupJSON();
+    const group = new Group(
+      groupJSON.id,
+      groupJSON.title,
+      groupJSON.description,
+      groupJSON.pages
+    );
 
     expect(group).toMatchObject({
       id: "group-1",
@@ -28,8 +34,12 @@ describe("Group", () => {
   });
 
   it("should handle HTML values", () => {
+    let groupJSON = createGroupJSON({ title: "<p>Section <em>1</em></p>" });
     const group = new Group(
-      createGroupJSON({ title: "<p>Section <em>1</em></p>" })
+      groupJSON.id,
+      groupJSON.title,
+      groupJSON.description,
+      groupJSON.pages
     );
 
     expect(group).toMatchObject({

--- a/src/eq_schema/Questionnaire.js
+++ b/src/eq_schema/Questionnaire.js
@@ -1,9 +1,8 @@
 /* eslint-disable camelcase */
-const Group = require("./Group");
+const Section = require("./Section");
 const Summary = require("./block-types/Summary");
 const Confirmation = require("./block-types/Confirmation");
 const { last } = require("lodash");
-const { getText } = require("../utils/HTMLUtils");
 
 class Questionnaire {
   constructor(questionnaireJson) {
@@ -15,36 +14,21 @@ class Questionnaire {
     this.data_version = "0.0.2";
     this.survey_id = questionnaireJson.surveyId || questionnaireId;
     this.title = questionnaireJson.title;
-    this.groups = this.buildGroups(questionnaireJson.sections);
+    this.sections = this.buildSections(questionnaireJson.sections);
     this.theme = questionnaireJson.theme;
     this.legal_basis = questionnaireJson.legalBasis;
-    this.navigation = this.buildNavigation(
-      questionnaireJson.navigation,
-      questionnaireJson.sections
-    );
+    this.navigation = { visible: questionnaireJson.navigation };
 
     this.buildSummaryOrConfirmation(questionnaireJson.summary);
   }
 
-  buildGroups(sections) {
-    return sections.map(section => new Group(section));
+  buildSections(sections) {
+    return sections.map(section => new Section(section));
   }
 
   buildSummaryOrConfirmation(summary) {
     const finalPage = summary ? new Summary() : new Confirmation();
-    last(this.groups).blocks.push(finalPage);
-  }
-
-  buildNavigation(visible, sections) {
-    return {
-      visible,
-      sections: sections.map(section => {
-        return {
-          title: getText(section.title),
-          group_order: [`group-${section.id}`]
-        };
-      })
-    };
+    last(last(this.sections).groups).blocks.push(finalPage);
   }
 }
 

--- a/src/eq_schema/Questionnaire.test.js
+++ b/src/eq_schema/Questionnaire.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 const Questionnaire = require("./Questionnaire");
 const Summary = require("./block-types/Summary");
-const Group = require("./Group");
+const Section = require("./Section");
 const { last } = require("lodash");
 
 describe("Questionnaire", () => {
@@ -41,14 +41,15 @@ describe("Questionnaire", () => {
       survey_id: "0112",
       title: "Quarterly Business Survey",
       theme: "default",
-      groups: [expect.any(Group)],
+      sections: [expect.any(Section)],
       legal_basis: "StatisticsOfTradeAct"
     });
   });
 
   it("should add a Summary to end of Questionnaire", () => {
     const questionnaire = new Questionnaire(createQuestionnaireJSON());
-    const finalGroup = last(questionnaire.groups);
+    const finalSection = last(questionnaire.sections);
+    const finalGroup = last(finalSection.groups);
     const finalPage = last(finalGroup.blocks);
 
     expect(finalPage).toBeInstanceOf(Summary);
@@ -83,25 +84,15 @@ describe("Questionnaire", () => {
 
     expect(questionnaire).toMatchObject({
       navigation: {
-        visible: true,
-        sections: [
-          {
-            title: "Section number 2",
-            group_order: ["group-2"]
-          },
-          {
-            title: "Section number 3",
-            group_order: ["group-3"]
-          }
-        ]
-      }
+        visible: true
+      },
+      sections: [{ id: "section-2" }, { id: "section-3" }]
     });
   });
 
   it("should strip out HTML from navigation sections", () => {
     const questionnaire = new Questionnaire(
       createQuestionnaireJSON({
-        navigation: true,
         sections: [
           {
             id: "2",
@@ -118,17 +109,16 @@ describe("Questionnaire", () => {
     );
 
     expect(questionnaire).toMatchObject({
-      navigation: {
-        visible: true,
-        sections: [
-          {
-            title: "Section number 2"
-          },
-          {
-            title: "Section number 3"
-          }
-        ]
-      }
+      sections: [
+        {
+          id: "section-2",
+          title: "Section number 2"
+        },
+        {
+          id: "section-3",
+          title: "Section number 3"
+        }
+      ]
     });
   });
 
@@ -143,15 +133,17 @@ describe("Questionnaire", () => {
     const questionnaire = new Questionnaire(
       createQuestionnaireJSON({ summary: true })
     );
-    expect(last(last(questionnaire.groups).blocks).type).toEqual("Summary");
+    const lastSection = last(questionnaire.sections);
+    const lastGroup = last(lastSection.groups);
+    expect(last(lastGroup.blocks).type).toEqual("Summary");
   });
 
   it("should add a confirmation page if summary is toggled off", () => {
     const questionnaire = new Questionnaire(
       createQuestionnaireJSON({ summary: false })
     );
-    expect(last(last(questionnaire.groups).blocks).type).toEqual(
-      "Confirmation"
-    );
+    const lastSection = last(questionnaire.sections);
+    const lastGroup = last(lastSection.groups);
+    expect(last(lastGroup.blocks).type).toEqual("Confirmation");
   });
 });

--- a/src/eq_schema/Section.js
+++ b/src/eq_schema/Section.js
@@ -1,0 +1,17 @@
+const Group = require("./Group");
+const { getText } = require("../utils/HTMLUtils");
+
+class Section {
+  constructor(section) {
+    this.id = `section-${section.id}`;
+    this.title = getText(section.title);
+    this.groups = this.buildGroups(section.id, this.title, section);
+  }
+
+  buildGroups(id, title, { description, pages }) {
+    // Sections always contain a single group currently
+    return [new Group(id, title, description, pages)];
+  }
+}
+
+module.exports = Section;

--- a/src/eq_schema/Section.test.js
+++ b/src/eq_schema/Section.test.js
@@ -1,0 +1,35 @@
+const Block = require("./Block");
+const Section = require("./Section");
+
+describe("Section", () => {
+  const createSectionJSON = options =>
+    Object.assign(
+      {
+        id: "1",
+        title: "Section 1",
+        pages: [
+          {
+            id: "2",
+            answers: []
+          }
+        ]
+      },
+      options
+    );
+
+  it("should build valid runner Section from Author section", () => {
+    const section = new Section(createSectionJSON());
+
+    expect(section).toMatchObject({
+      id: "section-1",
+      title: "Section 1",
+      groups: [
+        {
+          id: "group-1",
+          title: "Section 1",
+          blocks: [expect.any(Block)]
+        }
+      ]
+    });
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?
Groups are now children of sections in the runner schema. This change is for publisher to correctly transform authored schemas into the updated runner schema.

See https://github.com/ONSdigital/eq-survey-runner/pull/1473

### How to review 
Check that authored questionnaires can still be previewed
