### PR TITLE
improve reporting of schema validation errors

### DIFF
--- a/src/process/Convert.js
+++ b/src/process/Convert.js
@@ -10,17 +10,19 @@ class Convert {
   }
 
   async convert(authorJson) {
-    const output = new Questionnaire(authorJson);
+    const convertedQuestionnaire = new Questionnaire(authorJson);
 
-    const result = await this.schemaValidator.validate(output);
+    const result = await this.schemaValidator.validate(convertedQuestionnaire);
+
     if (!result.valid) {
       throw new ValidationError(
         "Converted author schema is not valid EQ schema.",
+        convertedQuestionnaire,
         result.errors
       );
     }
 
-    return output;
+    return convertedQuestionnaire;
   }
 }
 

--- a/src/validation/ValidationError.js
+++ b/src/validation/ValidationError.js
@@ -1,11 +1,20 @@
 class ValidationError extends Error {
-  constructor(message, validation) {
+  constructor(message, input, result) {
     super(message);
-    this.validation = validation;
+    this.result = result;
+    this.input = input;
+  }
+
+  toJSON() {
+    return {
+      message: this.message,
+      validatorInput: this.input,
+      validatorResult: this.result
+    };
   }
 
   toString() {
-    return this.message + "\n" + JSON.stringify(this.validation);
+    return this.message + "\n" + JSON.stringify(this.result);
   }
 }
 

--- a/src/validation/ValidationError.test.js
+++ b/src/validation/ValidationError.test.js
@@ -16,9 +16,13 @@ describe("validation error", () => {
       ]
     };
 
-    const validationError = new ValidationError(null, mockValidationObject);
+    const validationError = new ValidationError(
+      null,
+      null,
+      mockValidationObject
+    );
 
-    expect(validationError.validation).toBe(mockValidationObject);
+    expect(validationError.result).toBe(mockValidationObject);
   });
 
   it("should override toString", () => {
@@ -33,11 +37,36 @@ describe("validation error", () => {
 
     const validationError = new ValidationError(
       "Error message",
+      {},
       mockValidationObject
     );
     const errorMessage = validationError.toString();
 
     expect(errorMessage).toContain("Error message");
     expect(errorMessage).toContain(JSON.stringify(mockValidationObject));
+  });
+
+  it("should override toJSON", () => {
+    const mockValidationObject = {
+      validationErrors: [
+        {
+          error: "some error",
+          description: "some description"
+        }
+      ]
+    };
+
+    const mockQuestionnaire = {
+      id: 1,
+      title: "hello world"
+    };
+
+    const validationError = new ValidationError(
+      "Something has gone terribly wrong",
+      mockQuestionnaire,
+      mockValidationObject
+    );
+
+    expect(JSON.stringify(validationError)).toMatchSnapshot();
   });
 });

--- a/src/validation/__snapshots__/ValidationError.test.js.snap
+++ b/src/validation/__snapshots__/ValidationError.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`validation error should override toJSON 1`] = `"{\\"message\\":\\"Something has gone terribly wrong\\",\\"validatorInput\\":{\\"id\\":1,\\"title\\":\\"hello world\\"},\\"validatorResult\\":{\\"validationErrors\\":[{\\"error\\":\\"some error\\",\\"description\\":\\"some description\\"}]}}"`;


### PR DESCRIPTION
### What is the context of this PR?
We weren't giving much information in the event of an error from the schema validator. This PR makes a change so that the JSON supplied to schema-validator is given in publisher's HTTP response. 

### How to review 
Check error message is reasonable, code looks good