### PR TITLE
don't use same debug port as eq-author-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you have started the app with `docker-compose` then you can attach a debugger
       "name": "Attach to Container",
       "type": "node",
       "request": "attach",
-      "port": 5858,
+      "port": 5859,
       "address": "localhost",
       "restart": true,
       "sourceMaps": false,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,10 @@ services:
     environment:
       - EQ_SCHEMA_VALIDATOR_URL=http://eq-schema-validator:5000/validate
       - EQ_AUTHOR_API_URL=http://docker.for.mac.host.internal:4000/graphql
+      - NODE_ENV=development
     ports:
       - "9000:9000"
-      - "5858:5858" # open port for debugging
+      - "5859:5858" # open port for debugging
     volumes:
       - .:/app
     depends_on:


### PR DESCRIPTION
### What is the context of this PR?
We used port `5858` in both eq-author-api and eq-publisher, meaning they would clash if you start both apps. This switches debug port for publisher to `5859`, and updates README to document this.

