### PR TITLE
Added second label type for date ranges

### DIFF
--- a/src/api/queries.js
+++ b/src/api/queries.js
@@ -32,6 +32,9 @@ exports.getQuestionnaire = `
             pageType
             answers {
               ...answerFragment
+              ... on BasicAnswer {
+                secondaryLabel
+              }
               ... on MultipleChoiceAnswer {
                 options {
                   id

--- a/src/eq_schema/Question.js
+++ b/src/eq_schema/Question.js
@@ -30,16 +30,16 @@ class Question {
     return answers.map(answer => new Answer(answer));
   }
 
-  buildDateRangeAnswers({ id }) {
+  buildDateRangeAnswers({ id, label, secondaryLabel }) {
     return [
       new Answer({
-        label: "Period from",
+        label,
         type: "Date",
         id: `${id}-from`,
         mandatory: true
       }),
       new Answer({
-        label: "Period to",
+        label: secondaryLabel,
         type: "Date",
         id: `${id}-to`,
         mandatory: true

--- a/src/eq_schema/Question.test.js
+++ b/src/eq_schema/Question.test.js
@@ -59,7 +59,14 @@ describe("Question", () => {
 
   describe("DateRange", () => {
     it("should convert Author DateRange to Runner-compatible format", () => {
-      const answers = [{ type: "DateRange", id: "1" }];
+      const answers = [
+        {
+          type: "DateRange",
+          id: "1",
+          label: "Period from",
+          secondaryLabel: "Period to"
+        }
+      ];
       const question = new Question(createQuestionJSON({ answers }));
 
       expect(question).toMatchObject({


### PR DESCRIPTION
### What is the context of this PR?
Implemented changes to remove the hard-coded label and secondary label on date-ranges and allowed publisher to publish user defined labels.

### How to review 
All tests should pass and in the resultant json schema the date range should show user-defined labels

### Dependencies
 - ~ONSdigital/eq-author-graphql-schema#28~