### PR TITLE
Handle 400 response from validator

### DIFF
--- a/src/validation/ValidationApi.js
+++ b/src/validation/ValidationApi.js
@@ -12,14 +12,20 @@ class ValidationApi {
       valid: true
     };
 
-    const res = await this.http.post(this.validationApiUrl, {
-      body: json,
-      json: true
-    });
+    try {
+      const res = await this.http.post(this.validationApiUrl, {
+        body: json,
+        json: true
+      });
 
-    if (!isEmpty(res)) {
+      // TODO: remove after ONSdigital/eq-schema-validator/pull/42 is merged
+      if (!isEmpty(res)) {
+        result.valid = false;
+        result.errors = res.errors;
+      }
+    } catch ({ response }) {
       result.valid = false;
-      result.errors = res.errors;
+      result.errors = response.body.errors;
     }
 
     return result;

--- a/src/validation/ValidationApi.test.js
+++ b/src/validation/ValidationApi.test.js
@@ -32,17 +32,38 @@ describe("ValidationApi", () => {
       });
     });
 
-    it("should return invalid response", () => {
+    describe("error handling", () => {
       const errors = {
-        errors: { message: "Error message", detail: "Error details" }
+        message: "Error message",
+        detail: "Error details"
       };
-      mockRequest.post = jest.fn(() => Promise.resolve(errors));
-      expect(validationApi.validate({ test: "json" })).resolves.toMatchObject({
-        valid: false,
-        errors: {
-          message: "Error message",
-          detail: "Error details"
-        }
+
+      it("should return invalid response", () => {
+        mockRequest.post = jest.fn(() => Promise.resolve({ errors }));
+
+        expect(
+          validationApi.validate({ test: "json" })
+        ).resolves.toMatchObject({
+          valid: false,
+          errors
+        });
+      });
+
+      it("should handle non-200 reponses", () => {
+        mockRequest.post = jest.fn(() =>
+          Promise.reject({
+            response: {
+              body: { errors }
+            }
+          })
+        );
+
+        expect(
+          validationApi.validate({ test: "json" })
+        ).resolves.toMatchObject({
+          valid: false,
+          errors
+        });
       });
     });
   });

--- a/src/validation/ValidationApi.test.js
+++ b/src/validation/ValidationApi.test.js
@@ -12,13 +12,17 @@ describe("ValidationApi", () => {
     let mockRequest;
 
     beforeEach(() => {
-      mockRequest = jest.genMockFromModule("request-promise");
+      mockRequest = {
+        post: jest.fn()
+      };
+
       validationApi = new ValidationApi(url, mockRequest);
     });
 
     it("should pass the json to validation Api", () => {
       const json = { test: "json" };
       validationApi.validate(json);
+
       expect(mockRequest.post).toHaveBeenCalledWith(url, {
         body: json,
         json: true
@@ -26,7 +30,8 @@ describe("ValidationApi", () => {
     });
 
     it("should return valid response", () => {
-      mockRequest.post = jest.fn(() => Promise.resolve({}));
+      mockRequest.post.mockImplementation(() => Promise.resolve({}));
+
       expect(validationApi.validate({ test: "json" })).resolves.toEqual({
         valid: true
       });
@@ -39,7 +44,7 @@ describe("ValidationApi", () => {
       };
 
       it("should return invalid response", () => {
-        mockRequest.post = jest.fn(() => Promise.resolve({ errors }));
+        mockRequest.post.mockImplementation(() => Promise.resolve({ errors }));
 
         expect(
           validationApi.validate({ test: "json" })
@@ -50,7 +55,7 @@ describe("ValidationApi", () => {
       });
 
       it("should handle non-200 reponses", () => {
-        mockRequest.post = jest.fn(() =>
+        mockRequest.post.mockImplementation(() =>
           Promise.reject({
             response: {
               body: { errors }


### PR DESCRIPTION
### What is the context of this PR?
Schema validator will start sending `400` status code for invalid schemas. The request library we rejects the promise that scenario. Our existing code did not handle that possibility. This PR updates publisher to handle this, whilst maintaining backwards compatibility. Publisher should be merged/deployed before this PR: https://github.com/ONSdigital/eq-schema-validator/pull/42

### How to review 
Code looks OK, tests pass