### PR TITLE
remove backwards compatibility with older schema-validator

### DIFF
--- a/src/validation/ValidationApi.js
+++ b/src/validation/ValidationApi.js
@@ -1,5 +1,5 @@
 const request = require("request-promise");
-const { isEmpty } = require("lodash");
+const { get } = require("lodash/fp");
 
 class ValidationApi {
   constructor(validationApiUrl, http = request) {
@@ -7,28 +7,19 @@ class ValidationApi {
     this.http = http;
   }
 
-  async validate(json) {
-    const result = {
-      valid: true
-    };
-
-    try {
-      const res = await this.http.post(this.validationApiUrl, {
+  validate(json) {
+    return this.http
+      .post(this.validationApiUrl, {
         body: json,
         json: true
-      });
-
-      // TODO: remove after ONSdigital/eq-schema-validator/pull/42 is merged
-      if (!isEmpty(res)) {
-        result.valid = false;
-        result.errors = res.errors;
-      }
-    } catch ({ response }) {
-      result.valid = false;
-      result.errors = response.body.errors;
-    }
-
-    return result;
+      })
+      .then(() => ({
+        valid: true
+      }))
+      .catch(e => ({
+        valid: false,
+        errors: get(e, "response.body.errors")
+      }));
   }
 }
 

--- a/src/validation/ValidationApi.test.js
+++ b/src/validation/ValidationApi.test.js
@@ -13,7 +13,7 @@ describe("ValidationApi", () => {
 
     beforeEach(() => {
       mockRequest = {
-        post: jest.fn()
+        post: jest.fn(() => Promise.resolve())
       };
 
       validationApi = new ValidationApi(url, mockRequest);
@@ -43,17 +43,6 @@ describe("ValidationApi", () => {
         detail: "Error details"
       };
 
-      it("should return invalid response", () => {
-        mockRequest.post.mockImplementation(() => Promise.resolve({ errors }));
-
-        expect(
-          validationApi.validate({ test: "json" })
-        ).resolves.toMatchObject({
-          valid: false,
-          errors
-        });
-      });
-
       it("should handle non-200 reponses", () => {
         mockRequest.post.mockImplementation(() =>
           Promise.reject({
@@ -63,12 +52,10 @@ describe("ValidationApi", () => {
           })
         );
 
-        expect(
-          validationApi.validate({ test: "json" })
-        ).resolves.toMatchObject({
-          valid: false,
-          errors
-        });
+        const result = validationApi.validate({ test: "json" });
+        const expected = { valid: false, errors };
+
+        expect(result).resolves.toMatchObject(expected);
       });
     });
   });


### PR DESCRIPTION
### What is the context of this PR?
Removes backwards compatibility with older schema-validator (where `200` status was returned even in case of validation failure).

It felt clearer to use promises directly, rather than async/await, so I switched to that. 

### How to review 
Code looks good, tests pass