### PR TITLE
Remove answer alias from publisher

### DIFF
--- a/src/eq_schema/Answer.js
+++ b/src/eq_schema/Answer.js
@@ -4,7 +4,6 @@ const { isNil } = require("lodash/fp");
 class Answer {
   constructor(answer) {
     this.id = `answer-${answer.id}`;
-    this.alias = `answer_${answer.id}`;
     this.mandatory = answer.mandatory;
     this.type = answer.type;
     this.label = answer.label;

--- a/src/eq_schema/Answer.test.js
+++ b/src/eq_schema/Answer.test.js
@@ -22,7 +22,6 @@ describe("Answer", () => {
 
     expect(answer).toMatchObject({
       id: "answer-1",
-      alias: "answer_1",
       type: "PositiveInteger",
       mandatory: false,
       description: "This is a description"


### PR DESCRIPTION
Answer alias is removed from runner in https://github.com/ONSdigital/eq-survey-runner/pull/1533

This removes it from publisher.

Do not merge until runner PR is merged.