### PR TITLE
Fix piping

### DIFF
--- a/src/eq_schema/Answer.js
+++ b/src/eq_schema/Answer.js
@@ -4,14 +4,14 @@ const { merge } = require("lodash");
 
 class Answer {
   constructor(answer) {
-    this.id = `answer-${answer.id}`;
+    this.id = `answer${answer.id}`;
     this.mandatory = answer.mandatory;
     this.type = answer.type;
     this.label = answer.label;
     this.description = answer.description;
 
     if (!isNil(answer.parentAnswerId)) {
-      this.parent_answer_id = `answer-${answer.parentAnswerId}`;
+      this.parent_answer_id = `answer${answer.parentAnswerId}`;
     }
 
     if (answer.type === "Currency") {
@@ -55,7 +55,7 @@ class Answer {
 
   buildOtherOption(other) {
     return merge({}, this.buildOption(other.option), {
-      child_answer_id: `answer-${other.answer.id}`
+      child_answer_id: `answer${other.answer.id}`
     });
   }
 }

--- a/src/eq_schema/Answer.test.js
+++ b/src/eq_schema/Answer.test.js
@@ -21,7 +21,7 @@ describe("Answer", () => {
     const answer = new Answer(createAnswerJSON({ type: "PositiveInteger" }));
 
     expect(answer).toMatchObject({
-      id: "answer-1",
+      id: "answer1",
       type: "PositiveInteger",
       mandatory: false,
       description: "This is a description"
@@ -183,10 +183,10 @@ describe("Answer", () => {
       );
       expect(question.answers[1]).toEqual(
         expect.objectContaining({
-          parent_answer_id: "answer-1",
+          parent_answer_id: "answer1",
           description: "This is a description",
           mandatory: false,
-          id: "answer-4",
+          id: "answer4",
           label: "This is not a label",
           type: "TextField"
         })
@@ -200,7 +200,7 @@ describe("Answer", () => {
         expect.objectContaining({
           label,
           description,
-          child_answer_id: `answer-${checkboxWithOther.other.answer.id}`
+          child_answer_id: `answer${checkboxWithOther.other.answer.id}`
         })
       );
     });

--- a/src/eq_schema/Block.js
+++ b/src/eq_schema/Block.js
@@ -9,7 +9,7 @@ const pageTypeMappings = {
 
 class Block {
   constructor(title, description, page) {
-    this.id = "block-" + page.id.toString();
+    this.id = `block${page.id}`;
     this.title = getInnerHTML(title);
     this.description = getInnerHTML(description);
     this.type = this.convertPageType(page.pageType);

--- a/src/eq_schema/Block.test.js
+++ b/src/eq_schema/Block.test.js
@@ -22,7 +22,7 @@ describe("Block", () => {
     );
 
     expect(block).toMatchObject({
-      id: "block-1",
+      id: "block1",
       title: "section title",
       description: "section description",
       questions: [expect.any(Question)]
@@ -37,7 +37,7 @@ describe("Block", () => {
     );
 
     expect(block).toMatchObject({
-      id: "block-1",
+      id: "block1",
       title: "section <em>title</em>",
       description: "section <strong>description</strong>",
       questions: [expect.any(Question)]

--- a/src/eq_schema/Group.js
+++ b/src/eq_schema/Group.js
@@ -3,7 +3,7 @@ const { getInnerHTML } = require("../utils/HTMLUtils");
 
 class Group {
   constructor(id, title, description, pages) {
-    this.id = `group-${id}`;
+    this.id = `group${id}`;
     this.title = getInnerHTML(title);
     this.blocks = this.buildBlocks(this.title, description, pages);
   }

--- a/src/eq_schema/Group.test.js
+++ b/src/eq_schema/Group.test.js
@@ -27,7 +27,7 @@ describe("Group", () => {
     );
 
     expect(group).toMatchObject({
-      id: "group-1",
+      id: "group1",
       title: "Section 1",
       blocks: [expect.any(Block)]
     });

--- a/src/eq_schema/Question.js
+++ b/src/eq_schema/Question.js
@@ -11,7 +11,7 @@ const { isNil } = require("lodash");
 
 class Question {
   constructor(question) {
-    this.id = "question-" + question.id;
+    this.id = `question${question.id}`;
     this.title = processPipedText(question.title);
     this.guidance = processGuidance(question.guidance);
     this.description = processPipedText(question.description);
@@ -47,13 +47,13 @@ class Question {
       new Answer({
         label,
         type: "Date",
-        id: `${id}-from`,
+        id: `${id}from`,
         mandatory: true
       }),
       new Answer({
         label: secondaryLabel,
         type: "Date",
-        id: `${id}-to`,
+        id: `${id}to`,
         mandatory: true
       })
     ];

--- a/src/eq_schema/Question.test.js
+++ b/src/eq_schema/Question.test.js
@@ -18,7 +18,7 @@ describe("Question", () => {
     const question = new Question(createQuestionJSON());
 
     expect(question).toMatchObject({
-      id: "question-1",
+      id: "question1",
       title: "question title",
       type: "General",
       answers: [expect.any(Answer)]
@@ -75,13 +75,13 @@ describe("Question", () => {
           {
             label: "Period from",
             type: "Date",
-            id: "answer-1-from",
+            id: "answer1from",
             mandatory: true
           },
           {
             label: "Period to",
             type: "Date",
-            id: "answer-1-to",
+            id: "answer1to",
             mandatory: true
           }
         ]
@@ -174,7 +174,7 @@ describe("Question", () => {
         })
       );
 
-      expect(question.title).toEqual("{{answers.answer_123}}");
+      expect(question.title).toEqual("{{answers.answer123}}");
     });
 
     it("should handle piped values in guidance", () => {
@@ -185,7 +185,7 @@ describe("Question", () => {
       );
 
       expect(question.guidance.content[0]).toEqual({
-        title: "{{answers.answer_123}}"
+        title: "{{answers.answer123}}"
       });
     });
 
@@ -196,7 +196,7 @@ describe("Question", () => {
         })
       );
 
-      expect(question.description).toEqual("{{answers.answer_123}}");
+      expect(question.description).toEqual("{{answers.answer123}}");
     });
   });
 });

--- a/src/eq_schema/Questionnaire.test.js
+++ b/src/eq_schema/Questionnaire.test.js
@@ -86,7 +86,7 @@ describe("Questionnaire", () => {
       navigation: {
         visible: true
       },
-      sections: [{ id: "section-2" }, { id: "section-3" }]
+      sections: [{ id: "section2" }, { id: "section3" }]
     });
   });
 
@@ -111,11 +111,11 @@ describe("Questionnaire", () => {
     expect(questionnaire).toMatchObject({
       sections: [
         {
-          id: "section-2",
+          id: "section2",
           title: "Section number 2"
         },
         {
-          id: "section-3",
+          id: "section3",
           title: "Section number 3"
         }
       ]

--- a/src/eq_schema/Section.js
+++ b/src/eq_schema/Section.js
@@ -3,7 +3,7 @@ const { getText } = require("../utils/HTMLUtils");
 
 class Section {
   constructor(section) {
-    this.id = `section-${section.id}`;
+    this.id = `section${section.id}`;
     this.title = getText(section.title);
     this.groups = this.buildGroups(section.id, this.title, section);
   }

--- a/src/eq_schema/Section.test.js
+++ b/src/eq_schema/Section.test.js
@@ -21,11 +21,11 @@ describe("Section", () => {
     const section = new Section(createSectionJSON());
 
     expect(section).toMatchObject({
-      id: "section-1",
+      id: "section1",
       title: "Section 1",
       groups: [
         {
-          id: "group-1",
+          id: "group1",
           title: "Section 1",
           blocks: [expect.any(Block)]
         }

--- a/src/middleware/fetchData.test.js
+++ b/src/middleware/fetchData.test.js
@@ -17,7 +17,7 @@ describe("fetchData", () => {
     };
 
     API = {
-      getAuthorData: jest.fn()
+      getAuthorData: jest.fn(() => Promise.resolve({}))
     };
 
     next = jest.fn();
@@ -25,27 +25,25 @@ describe("fetchData", () => {
     fetcher = fetchData(API);
   });
 
-  it("should request data from API", () => {
-    fetcher(req, res, next);
+  it("should request data from API", async () => {
+    await fetcher(req, res, next);
 
     expect(API.getAuthorData).toHaveBeenCalledWith(req.params.questionnaireId);
   });
 
-  it("should pass error to next middleware if API errors", () => {
+  it("should pass error to next middleware if API errors", async () => {
     const error = new Error("oops");
     API.getAuthorData.mockImplementation(() => {
       throw error;
     });
 
-    fetcher(req, res, next);
+    await fetcher(req, res, next);
 
     expect(next).toHaveBeenCalledWith(error);
   });
 
   it("should respond with 404 if no questionnaire returned", async () => {
-    API.getAuthorData.mockImplementation(() => ({
-      errors: {}
-    }));
+    API.getAuthorData.mockImplementation(() => Promise.resolve({ errors: {} }));
 
     await fetcher(req, res, next);
 
@@ -61,9 +59,11 @@ describe("fetchData", () => {
   it("should assign questionnaire for next middleware", async () => {
     const questionnaire = { id: "123" };
 
-    API.getAuthorData.mockImplementation(() => ({
-      data: { questionnaire }
-    }));
+    API.getAuthorData.mockImplementation(() =>
+      Promise.resolve({
+        data: { questionnaire }
+      })
+    );
 
     await fetcher(req, res, next);
 

--- a/src/utils/convertPipes.js
+++ b/src/utils/convertPipes.js
@@ -9,7 +9,7 @@ const filterMap = {
 const convertElementToPipe = $elem => {
   const { piped, id, type } = $elem.data();
   const filter = filterMap[type];
-  let inner = `${piped}.answer_${id}`;
+  let inner = `${piped}.answer${id}`;
 
   if (filter) {
     inner += `|${filter}`;

--- a/src/utils/convertPipes.test.js
+++ b/src/utils/convertPipes.test.js
@@ -22,7 +22,7 @@ describe("convertPipes", () => {
 
   it("should convert relevant elements to pipe format", () => {
     const html = createPipe();
-    expect(convertPipes(html)).toEqual("{{answers.answer_123}}");
+    expect(convertPipes(html)).toEqual("{{answers.answer123}}");
   });
 
   it("should handle multiple piped values", () => {
@@ -31,7 +31,7 @@ describe("convertPipes", () => {
     const html = `${pipe1}${pipe2}`;
 
     expect(convertPipes(html)).toEqual(
-      "{{answers.answer_123}}{{answers.answer_456}}"
+      "{{answers.answer123}}{{answers.answer456}}"
     );
   });
 
@@ -41,28 +41,26 @@ describe("convertPipes", () => {
     const html = `hello ${pipe1}${pipe2} world`;
 
     expect(convertPipes(html)).toEqual(
-      "hello {{answers.answer_123}}{{answers.answer_456}} world"
+      "hello {{answers.answer123}}{{answers.answer456}} world"
     );
   });
 
   describe("formatting", () => {
     it("should format Date answers with `format_date`", () => {
       const html = createPipe({ id: "123", type: "Date" });
-      expect(convertPipes(html)).toEqual("{{answers.answer_123|format_date}}");
+      expect(convertPipes(html)).toEqual("{{answers.answer123|format_date}}");
     });
 
     it("should format Currency answers with `format_currency`", () => {
       const html = createPipe({ id: "123", type: "Currency" });
       expect(convertPipes(html)).toEqual(
-        "{{answers.answer_123|format_currency}}"
+        "{{answers.answer123|format_currency}}"
       );
     });
 
     it("should format Number answers with `format_number`", () => {
       const html = createPipe({ id: "123", type: "Number" });
-      expect(convertPipes(html)).toEqual(
-        "{{answers.answer_123|format_number}}"
-      );
+      expect(convertPipes(html)).toEqual("{{answers.answer123|format_number}}");
     });
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
Since runner has dropped support for aliases, we need to use IDs for piping. Currently IDs contain hyphens, which mean they are not valid python identifiers. This PR drops the hyphen. 

* Previous format: `[type]-[id]`
* New format: `[type][id]`

This PR also fixes some issues i discovered with `fetchData` tests

### How to review 
Create questionnaire with piping in author, preview in runner, ensure values are piped correctly