### PR TITLE
Add mandatory metadata to published runner schema.

### DIFF
--- a/src/eq_schema/Questionnaire.js
+++ b/src/eq_schema/Questionnaire.js
@@ -18,6 +18,7 @@ class Questionnaire {
     this.theme = questionnaireJson.theme;
     this.legal_basis = questionnaireJson.legalBasis;
     this.navigation = { visible: questionnaireJson.navigation };
+    this.metadata = this.buildMetadata();
 
     this.buildSummaryOrConfirmation(questionnaireJson.summary);
   }
@@ -29,6 +30,17 @@ class Questionnaire {
   buildSummaryOrConfirmation(summary) {
     const finalPage = summary ? new Summary() : new Confirmation();
     last(last(this.sections).groups).blocks.push(finalPage);
+  }
+
+  buildMetadata() {
+    return {
+      user_id: {
+        validator: "string"
+      },
+      period_id: {
+        validator: "string"
+      }
+    };
   }
 }
 

--- a/src/eq_schema/Questionnaire.test.js
+++ b/src/eq_schema/Questionnaire.test.js
@@ -146,4 +146,17 @@ describe("Questionnaire", () => {
     const lastGroup = last(lastSection.groups);
     expect(last(lastGroup.blocks).type).toEqual("Confirmation");
   });
+
+  it("should build the default metadata", () => {
+    expect(questionnaire).toMatchObject({
+      metadata: {
+        user_id: {
+          validator: "string"
+        },
+        period_id: {
+          validator: "string"
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
### What is the context of this PR?
This PR adds mandatory schema-level metadata into the resulting JSON in order to support a change being made to the eQ schema validator.

For now, the values have been hard coded. There is another story on the backlog for to modify Author to allow users to dynamically specify metadata values. Publisher will need to be updated again in a future change to support this.

### How to review 
Changes look okay, tests and checks pass.
Should generate valid JSON against schema validator branch `specify-required-metadata-in-schema`.

### Dependencies
 - https://github.com/ONSdigital/eq-schema-validator/pull/50
