### PR TITLE
RU Name mandatory in metadata

### DIFF
--- a/src/eq_schema/Questionnaire.js
+++ b/src/eq_schema/Questionnaire.js
@@ -39,6 +39,9 @@ class Questionnaire {
       },
       period_id: {
         validator: "string"
+      },
+      ru_name: {
+        validator: "string"
       }
     };
   }

--- a/src/eq_schema/Questionnaire.test.js
+++ b/src/eq_schema/Questionnaire.test.js
@@ -155,6 +155,9 @@ describe("Questionnaire", () => {
         },
         period_id: {
           validator: "string"
+        },
+        ru_name: {
+          validator: "string"
         }
       }
     });


### PR DESCRIPTION
### What is the context of this PR?
The introduction page expects RU Name to be present for default and northernireland themes.

This PR adds ru_name as required metadata in the schemas.