### PR TITLE
Prevent routing on last page in section

### DIFF
--- a/src/eq_schema/Block.js
+++ b/src/eq_schema/Block.js
@@ -3,11 +3,24 @@ const RoutingRule = require("./RoutingRule");
 const RoutingDestination = require("./RoutingDestination");
 const { get, isNil, remove, isEmpty } = require("lodash");
 const { getInnerHTML } = require("../utils/HTMLUtils");
+const { flow, getOr, last, map, some } = require("lodash/fp");
 
 const pageTypeMappings = {
   QuestionPage: "Question",
   InterstitialPage: "Interstitial"
 };
+
+const getLastPage = flow(
+  getOr([], "pages"),
+  last
+);
+
+const isLastPageInSection = (page, ctx) =>
+  flow(
+    getOr([], "sections"),
+    map(getLastPage),
+    some({ id: page.id })
+  )(ctx);
 
 class Block {
   constructor(title, description, page, ctx) {
@@ -17,7 +30,7 @@ class Block {
     this.type = this.convertPageType(page.pageType);
     this.questions = this.buildQuestions(page);
 
-    if (!isNil(page.routingRuleSet)) {
+    if (!isLastPageInSection(page, ctx) && !isNil(page.routingRuleSet)) {
       // eslint-disable-next-line camelcase
       this.routing_rules = this.buildRoutingRules(
         page.routingRuleSet,
@@ -51,3 +64,4 @@ class Block {
 }
 
 module.exports = Block;
+module.exports.isLastPageInSection = isLastPageInSection;

--- a/src/eq_schema/Block.test.js
+++ b/src/eq_schema/Block.test.js
@@ -1,4 +1,5 @@
 const Block = require("./Block");
+const { isLastPageInSection } = require("./Block");
 const Question = require("./Question");
 const ctx = {};
 
@@ -68,6 +69,29 @@ describe("Block", () => {
       );
 
       expect(block.type).toEqual("Interstitial");
+    });
+  });
+
+  describe("isNotLastPageInSection", () => {
+    const questionnaire = {
+      sections: [
+        {
+          pages: [{ id: "1" }, { id: "2" }]
+        },
+        {
+          pages: [{ id: "3" }, { id: "4" }]
+        }
+      ]
+    };
+
+    it("should return true if is a last page", () => {
+      expect(isLastPageInSection({ id: "2" }, questionnaire)).toBe(true);
+      expect(isLastPageInSection({ id: "4" }, questionnaire)).toBe(true);
+    });
+
+    it("should return false if not a last page in a section", () => {
+      expect(isLastPageInSection({ id: "1" }, questionnaire)).toBe(false);
+      expect(isLastPageInSection({ id: "3" }, questionnaire)).toBe(false);
     });
   });
 });

--- a/src/eq_schema/RoutingRule.test.js
+++ b/src/eq_schema/RoutingRule.test.js
@@ -1,6 +1,6 @@
 const Block = require("./Block");
 const Question = require("./Question");
-const { concat, set } = require("lodash");
+const { concat } = require("lodash");
 
 const nextPageGoto = {
   __typename: "LogicalDestination",
@@ -169,43 +169,6 @@ describe("Rule", () => {
     });
   });
 
-  // eslint-disable-next-line jest/no-disabled-tests
-  xit(
-    "should route to next section if next is chosen while at the end of a section",
-    () => {
-      let ruleJSON = createRuleJSON(nextPageGoto, basicRadioCondition);
-
-      ruleJSON.id = 3;
-
-      const block = new Block(
-        "section title",
-        "section description",
-        ruleJSON,
-        ctx
-      );
-
-      expect(block).toMatchObject({
-        id: "block3",
-        title: "section title",
-        description: "section description",
-        questions: [expect.any(Question)],
-        // eslint-disable-next-line camelcase
-        routing_rules: [
-          {
-            goto: {
-              group: "group2",
-              when: [
-                { id: "answer2", condition: "not equals", value: "no" },
-                { id: "answer2", condition: "not equals", value: "maybe" }
-              ]
-            }
-          },
-          { goto: { group: "group2" } }
-        ]
-      });
-    }
-  );
-
   it("should build valid runner routing with multiple conditions", () => {
     const twoConditions = concat(basicRadioCondition, secondCondition);
 
@@ -237,40 +200,4 @@ describe("Rule", () => {
       ]
     });
   });
-
-  // eslint-disable-next-line jest/no-disabled-tests
-  xit(
-    "should build valid runner routing to next page if its the last page in questionnaire",
-    () => {
-      const lastPage = createRuleJSON(nextPageGoto, basicRadioCondition);
-
-      set(lastPage, "id", 9);
-
-      const block = new Block(
-        "section title",
-        "section description",
-        lastPage,
-        ctx
-      );
-      expect(block).toMatchObject({
-        id: "block9",
-        title: "section title",
-        description: "section description",
-        questions: [expect.any(Question)],
-        // eslint-disable-next-line camelcase
-        routing_rules: [
-          {
-            goto: {
-              group: "summary-group",
-              when: [
-                { id: "answer2", condition: "not equals", value: "no" },
-                { id: "answer2", condition: "not equals", value: "maybe" }
-              ]
-            }
-          },
-          { goto: { group: "summary-group" } }
-        ]
-      });
-    }
-  );
 });

--- a/src/eq_schema/RoutingRule.test.js
+++ b/src/eq_schema/RoutingRule.test.js
@@ -169,38 +169,42 @@ describe("Rule", () => {
     });
   });
 
-  it("should route to next section if next is chosen while at the end of a section", () => {
-    let ruleJSON = createRuleJSON(nextPageGoto, basicRadioCondition);
+  // eslint-disable-next-line jest/no-disabled-tests
+  xit(
+    "should route to next section if next is chosen while at the end of a section",
+    () => {
+      let ruleJSON = createRuleJSON(nextPageGoto, basicRadioCondition);
 
-    ruleJSON.id = 3;
+      ruleJSON.id = 3;
 
-    const block = new Block(
-      "section title",
-      "section description",
-      ruleJSON,
-      ctx
-    );
+      const block = new Block(
+        "section title",
+        "section description",
+        ruleJSON,
+        ctx
+      );
 
-    expect(block).toMatchObject({
-      id: "block3",
-      title: "section title",
-      description: "section description",
-      questions: [expect.any(Question)],
-      // eslint-disable-next-line camelcase
-      routing_rules: [
-        {
-          goto: {
-            group: "group2",
-            when: [
-              { id: "answer2", condition: "not equals", value: "no" },
-              { id: "answer2", condition: "not equals", value: "maybe" }
-            ]
-          }
-        },
-        { goto: { group: "group2" } }
-      ]
-    });
-  });
+      expect(block).toMatchObject({
+        id: "block3",
+        title: "section title",
+        description: "section description",
+        questions: [expect.any(Question)],
+        // eslint-disable-next-line camelcase
+        routing_rules: [
+          {
+            goto: {
+              group: "group2",
+              when: [
+                { id: "answer2", condition: "not equals", value: "no" },
+                { id: "answer2", condition: "not equals", value: "maybe" }
+              ]
+            }
+          },
+          { goto: { group: "group2" } }
+        ]
+      });
+    }
+  );
 
   it("should build valid runner routing with multiple conditions", () => {
     const twoConditions = concat(basicRadioCondition, secondCondition);
@@ -234,35 +238,39 @@ describe("Rule", () => {
     });
   });
 
-  it("should build valid runner routing to next page if its the last page in questionnaire", () => {
-    const lastPage = createRuleJSON(nextPageGoto, basicRadioCondition);
+  // eslint-disable-next-line jest/no-disabled-tests
+  xit(
+    "should build valid runner routing to next page if its the last page in questionnaire",
+    () => {
+      const lastPage = createRuleJSON(nextPageGoto, basicRadioCondition);
 
-    set(lastPage, "id", 9);
+      set(lastPage, "id", 9);
 
-    const block = new Block(
-      "section title",
-      "section description",
-      lastPage,
-      ctx
-    );
-    expect(block).toMatchObject({
-      id: "block9",
-      title: "section title",
-      description: "section description",
-      questions: [expect.any(Question)],
-      // eslint-disable-next-line camelcase
-      routing_rules: [
-        {
-          goto: {
-            group: "summary-group",
-            when: [
-              { id: "answer2", condition: "not equals", value: "no" },
-              { id: "answer2", condition: "not equals", value: "maybe" }
-            ]
-          }
-        },
-        { goto: { group: "summary-group" } }
-      ]
-    });
-  });
+      const block = new Block(
+        "section title",
+        "section description",
+        lastPage,
+        ctx
+      );
+      expect(block).toMatchObject({
+        id: "block9",
+        title: "section title",
+        description: "section description",
+        questions: [expect.any(Question)],
+        // eslint-disable-next-line camelcase
+        routing_rules: [
+          {
+            goto: {
+              group: "summary-group",
+              when: [
+                { id: "answer2", condition: "not equals", value: "no" },
+                { id: "answer2", condition: "not equals", value: "maybe" }
+              ]
+            }
+          },
+          { goto: { group: "summary-group" } }
+        ]
+      });
+    }
+  );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3811,8 +3811,8 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
 prettier@^1.5.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.3.tgz#59dadc683345ec6b88f88b94ed4ae7e1da394bfe"
+  version "1.13.7"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
 
 pretty-format@^22.4.3:
   version "22.4.3"


### PR DESCRIPTION
### What is the context of this PR?
The implementation of basic routing on Author allows authors to specify rules that goto future pages in the same section, future sections and the end of the questionnaire.

Survey runner does not currently support routing between sections of the questionnaire. As such, the ability to navigate to future sections has been temporarily removed from routing.

A consequence of this is that a further change is being made to prevent authors from specifying routing rules on the last page of a section.

This PR makes a specific check within author to prevent routing rules from being processed for the last page in a section. This is to work around an edge case where a page may become the last page in a section e.g. after deletion of another page.
Hopefully once the ability to route across sections has been supported by survey runner, this logic can be reverted.

### How to review 
Code change looks good. All tests and checks pass.
