### PR TITLE
Pin version of eslint-scope package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "lint": "eslint .",
     "precommit": "lint-staged"
   },
+  "resolutions": {
+    "eslint-scope": "3.7.1"
+  },
   "lint-staged": {
-    "*.js": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.js": ["prettier --write", "git add"]
   },
   "dependencies": {
     "apollo-fetch": "^0.7.0",
@@ -39,17 +39,13 @@
     "lint-staged": "^7.0.5",
     "prettier": "^1.5.3"
   },
-  "moduleRoots": [
-    "src/"
-  ],
+  "moduleRoots": ["src/"],
   "engines": {
     "node": ">=7.10.0"
   },
   "jest": {
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
-    "collectCoverageFrom": [
-      "src/**/*.js"
-    ]
+    "collectCoverageFrom": ["src/**/*.js"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1296,7 +1296,7 @@ eslint-plugin-react@^7.0.1:
     has "^1.0.1"
     jsx-ast-utils "^2.0.0"
 
-eslint-scope@^3.7.1:
+eslint-scope@3.7.1, eslint-scope@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   dependencies:


### PR DESCRIPTION
### What is the context of this PR?
This PR pins the version of esline-scope package to 3.7.1 as per https://github.com/eslint/eslint-scope/issues/39.

### How to review 
Version of eslint-scope package should be pinned to 3.7.1 on install.
