### PR TITLE
Fixed the issue preventing routing from working with 'other' options.

### DIFF
--- a/src/api/queries.js
+++ b/src/api/queries.js
@@ -80,6 +80,12 @@ exports.getQuestionnaire = `
                         id
                         label
                       }
+                      other {
+                        option {
+                          id
+                          label
+                        }
+                      }
                     }
                   }
                   routingValue {

--- a/src/eq_schema/RoutingConditions.js
+++ b/src/eq_schema/RoutingConditions.js
@@ -1,6 +1,17 @@
-const { flow, keyBy, map, flatMap, xor } = require("lodash/fp");
+const { flow, keyBy, map, flatMap, xor, concat } = require("lodash/fp");
 
-const createOptionByIdLookup = flow(flatMap("answer.options"), keyBy("id"));
+const getAllOptions = condition => {
+  if (condition.answer.other) {
+    return concat(condition.answer.options, condition.answer.other.option);
+  } else {
+    return condition.answer.options;
+  }
+};
+
+const createOptionByIdLookup = flow(
+  flatMap(getAllOptions),
+  keyBy("id")
+);
 
 class RoutingConditions {
   constructor(conditions) {
@@ -11,7 +22,7 @@ class RoutingConditions {
     const optionById = createOptionByIdLookup(conditions);
 
     return flatMap(condition => {
-      const optionIds = map("id", condition.answer.options);
+      const optionIds = map("id", getAllOptions(condition));
       const unselectedIds = xor(condition.routingValue.value, optionIds);
 
       return unselectedIds

--- a/src/eq_schema/RoutingRule.test.js
+++ b/src/eq_schema/RoutingRule.test.js
@@ -20,6 +20,36 @@ const absoluteSectionGoto = {
   }
 };
 
+const otherCondition = [
+  {
+    id: 1,
+    comparator: "Equal",
+    answer: {
+      id: 3,
+      type: "Radio",
+      options: [
+        {
+          id: 4,
+          label: "pepperoni"
+        },
+        {
+          id: 5,
+          label: "pineapple"
+        }
+      ],
+      other: {
+        option: {
+          id: 6,
+          label: "other"
+        }
+      }
+    },
+    routingValue: {
+      value: [5]
+    }
+  }
+];
+
 const secondCondition = {
   id: 2,
   comparator: "Equal",
@@ -167,6 +197,36 @@ describe("Rule", () => {
           }
         },
         { goto: { group: "summary-group" } }
+      ]
+    });
+  });
+
+  it("should build valid runner routing with 'other' answers", () => {
+    const block = new Block(
+      "section title",
+      "section description",
+      createRuleJSON(nextPageGoto, otherCondition),
+      ctx
+    );
+
+    expect(block).toMatchObject({
+      id: "block1",
+      title: "section title",
+      description: "section description",
+      questions: [expect.any(Question)],
+      // eslint-disable-next-line camelcase
+      routing_rules: [
+        {
+          goto: {
+            block: "block2",
+            when: [
+              { id: "answer3", condition: "not equals", value: "pepperoni" },
+              { id: "answer3", condition: "not equals", value: "other" },
+              { id: "answer3", condition: "set" }
+            ]
+          }
+        },
+        { goto: { block: "block2" } }
       ]
     });
   });


### PR DESCRIPTION
### What is the context of this PR?
Routing was broken on "other" options as these options are in a different path on the answer object. This PR fixes this issue and allows routing based on other options.

### How to review 
The new test passes and routing on "other" options is possible again.