### PR TITLE
Removed all mention of section descriptions

### DIFF
--- a/src/eq_schema/Block.js
+++ b/src/eq_schema/Block.js
@@ -23,10 +23,9 @@ const isLastPageInSection = (page, ctx) =>
   )(ctx);
 
 class Block {
-  constructor(title, description, page, ctx) {
+  constructor(title, page, ctx) {
     this.id = `block${page.id}`;
     this.title = getInnerHTML(title);
-    this.description = getInnerHTML(description);
     this.type = this.convertPageType(page.pageType);
     this.questions = this.buildQuestions(page);
 

--- a/src/eq_schema/Block.test.js
+++ b/src/eq_schema/Block.test.js
@@ -17,17 +17,11 @@ describe("Block", () => {
     );
 
   it("should build valid runner Block from Author page", () => {
-    const block = new Block(
-      "section title",
-      "section description",
-      createBlockJSON(),
-      ctx
-    );
+    const block = new Block("section title", createBlockJSON(), ctx);
 
     expect(block).toMatchObject({
       id: "block1",
       title: "section title",
-      description: "section description",
       questions: [expect.any(Question)]
     });
   });
@@ -35,7 +29,6 @@ describe("Block", () => {
   it("should handle HTML values", () => {
     const block = new Block(
       "<p>section <em>title</em>",
-      "<p>section <strong>description</strong></p>",
       createBlockJSON(),
       ctx
     );
@@ -43,7 +36,6 @@ describe("Block", () => {
     expect(block).toMatchObject({
       id: "block1",
       title: "section <em>title</em>",
-      description: "section <strong>description</strong>",
       questions: [expect.any(Question)]
     });
   });
@@ -52,7 +44,6 @@ describe("Block", () => {
     it("should convert QuestionPage to Questionnaire", () => {
       const block = new Block(
         "section title",
-        "section description",
         createBlockJSON({ pageType: "QuestionPage" }),
         ctx
       );
@@ -63,7 +54,6 @@ describe("Block", () => {
     it("should convert InterstitialPage to Interstitial", () => {
       const block = new Block(
         "section title",
-        "section description",
         createBlockJSON({ pageType: "InterstitialPage" }),
         ctx
       );

--- a/src/eq_schema/Group.js
+++ b/src/eq_schema/Group.js
@@ -2,14 +2,14 @@ const Block = require("./Block");
 const { getInnerHTML } = require("../utils/HTMLUtils");
 
 class Group {
-  constructor(id, title, description, pages, ctx) {
+  constructor(id, title, pages, ctx) {
     this.id = `group${id}`;
     this.title = getInnerHTML(title);
-    this.blocks = this.buildBlocks(this.title, description, pages, ctx);
+    this.blocks = this.buildBlocks(this.title, pages, ctx);
   }
 
-  buildBlocks(title, description, pages, ctx) {
-    return pages.map(page => new Block(title, description, page, ctx));
+  buildBlocks(title, pages, ctx) {
+    return pages.map(page => new Block(title, page, ctx));
   }
 }
 

--- a/src/eq_schema/Group.test.js
+++ b/src/eq_schema/Group.test.js
@@ -23,7 +23,6 @@ describe("Group", () => {
     const group = new Group(
       groupJSON.id,
       groupJSON.title,
-      groupJSON.description,
       groupJSON.pages,
       ctx
     );
@@ -40,7 +39,6 @@ describe("Group", () => {
     const group = new Group(
       groupJSON.id,
       groupJSON.title,
-      groupJSON.description,
       groupJSON.pages,
       ctx
     );

--- a/src/eq_schema/RoutingRule.test.js
+++ b/src/eq_schema/RoutingRule.test.js
@@ -146,14 +146,12 @@ describe("Rule", () => {
   it("should build valid runner routing to next page", () => {
     const block = new Block(
       "section title",
-      "section description",
       createRuleJSON(nextPageGoto, basicRadioCondition),
       ctx
     );
     expect(block).toMatchObject({
       id: "block1",
       title: "section title",
-      description: "section description",
       questions: [expect.any(Question)],
       // eslint-disable-next-line camelcase
       routing_rules: [
@@ -175,14 +173,12 @@ describe("Rule", () => {
   it("should build valid runner routing to the End of Questionnaire", () => {
     const block = new Block(
       "section title",
-      "section description",
       createRuleJSON(endQuestionnaireGoto, basicRadioCondition),
       ctx
     );
     expect(block).toMatchObject({
       id: "block1",
       title: "section title",
-      description: "section description",
       questions: [expect.any(Question)],
       // eslint-disable-next-line camelcase
       routing_rules: [
@@ -204,7 +200,6 @@ describe("Rule", () => {
   it("should build valid runner routing with 'other' answers", () => {
     const block = new Block(
       "section title",
-      "section description",
       createRuleJSON(nextPageGoto, otherCondition),
       ctx
     );
@@ -212,7 +207,6 @@ describe("Rule", () => {
     expect(block).toMatchObject({
       id: "block1",
       title: "section title",
-      description: "section description",
       questions: [expect.any(Question)],
       // eslint-disable-next-line camelcase
       routing_rules: [
@@ -236,12 +230,11 @@ describe("Rule", () => {
 
     const multiRules = createRuleJSON(absoluteSectionGoto, twoConditions);
 
-    const block = new Block("section title", "section description", multiRules);
+    const block = new Block("section title", multiRules);
 
     expect(block).toMatchObject({
       id: "block1",
       title: "section title",
-      description: "section description",
       questions: [expect.any(Question)],
       // eslint-disable-next-line camelcase
       routing_rules: [

--- a/src/eq_schema/Section.js
+++ b/src/eq_schema/Section.js
@@ -8,9 +8,9 @@ class Section {
     this.groups = this.buildGroups(section.id, this.title, section, ctx);
   }
 
-  buildGroups(id, title, { description, pages }, ctx) {
+  buildGroups(id, title, { pages }, ctx) {
     // Sections always contain a single group currently
-    return [new Group(id, title, description, pages, ctx)];
+    return [new Group(id, title, pages, ctx)];
   }
 }
 


### PR DESCRIPTION
### What is the context of this PR?
There was a issue with all published schemas not being able to make it though validation as the section description was still being used after it had been removed.

### How to review 
Changes are reasonable and all mention of section description has been removed, also the schema should now pass validation.
