### PR TITLE
Fix error when destructuring min value when validation is undefined.

### DIFF
--- a/src/eq_schema/Answer.js
+++ b/src/eq_schema/Answer.js
@@ -10,7 +10,7 @@ class Answer {
     this.label = answer.label;
     this.description = answer.description;
 
-    if (has(answer, "validation")) {
+    if (!isNil(answer.validation)) {
       const { minValue, maxValue } = answer.validation;
       this.buildValidation(minValue, "min_value");
       this.buildValidation(maxValue, "max_value");

--- a/src/eq_schema/Answer.test.js
+++ b/src/eq_schema/Answer.test.js
@@ -87,6 +87,15 @@ describe("Answer", () => {
     });
   });
 
+  it("should not add validation if undefined", () => {
+    const answer = new Answer(
+      createAnswerJSON({
+        validation: null
+      })
+    );
+    expect(answer.validation).toBeUndefined();
+  });
+
   describe("converting options", () => {
     it("should not add options for basic answer types", () => {
       const answer = new Answer(createAnswerJSON());


### PR DESCRIPTION
### What is the context of this PR?
This PR is a hotfix for an error being observed in preprod when previewing the census questionnaire.

A check has been added to prevent destructuring minValue validation if validation is undefined or null. A failing test has also been added.

### How to review 
Changes look sensible and all checks and tests pass.
