### PR TITLE
Added methods to allow mutually exclusive

### DIFF
--- a/src/api/queries.js
+++ b/src/api/queries.js
@@ -126,6 +126,9 @@ exports.getQuestionnaire = `
                 options {
                   ...optionFragment
                 }
+                mutuallyExclusiveOption {
+                  ...optionFragment
+                }
                 other {
                   option {
                     ...optionFragment

--- a/src/eq_schema/Answer.js
+++ b/src/eq_schema/Answer.js
@@ -47,6 +47,13 @@ class Answer {
     if (!isNil(answer.other)) {
       this.options = this.options.concat(this.buildOtherOption(answer.other));
     }
+
+    if (!isNil(answer.mutuallyExclusiveOption)) {
+      this.type = "MutuallyExclusiveCheckbox";
+      this.options = this.options.concat(
+        this.buildOption(answer.mutuallyExclusiveOption)
+      );
+    }
   }
 
   static buildChildAnswer(

--- a/src/eq_schema/Answer.test.js
+++ b/src/eq_schema/Answer.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 const Answer = require("./Answer");
 const Question = require("./Question");
+const { last } = require("lodash");
 
 describe("Answer", () => {
   const createAnswerJSON = answer =>
@@ -133,6 +134,57 @@ describe("Answer", () => {
           description: "Another description"
         }
       ]);
+    });
+
+    it("should should always put Exclusive options at the end", () => {
+      const answer = new Answer(
+        createAnswerJSON({
+          type: "Checkbox",
+          options: [
+            {
+              id: 5,
+              label: "Option one",
+              description: "A short description"
+            },
+            {
+              id: 2,
+              label: "Option two",
+              description: "Another description"
+            }
+          ],
+          other: {
+            option: {
+              id: 3,
+              label: "Other",
+              description: "Hello"
+            },
+            answer: {
+              id: 4,
+              description: "This is a description",
+              guidance: "Here's your guidance",
+              properties: {
+                required: false
+              },
+              qCode: "20",
+              label: "This is not a label",
+              type: "TextField"
+            }
+          },
+          mutuallyExclusiveOption: {
+            id: 1,
+            label: "Option three",
+            description: "I am mutually Exclusive"
+          }
+        })
+      );
+
+      expect(answer.type).toEqual("MutuallyExclusiveCheckbox");
+
+      expect(last(answer.options)).toEqual({
+        label: "Option three",
+        value: "Option three",
+        description: "I am mutually Exclusive"
+      });
     });
 
     it("should omit child_answer_id if not supplied", () => {


### PR DESCRIPTION
### What is the context of this PR?
This PR add the methods allowing Publisher to convert Author mutually exclusive answers to Runner acceptable format. 

### How to review 
Tests are passing and the new schema pass validation and is displayed correctly within Runner.

### Dependency 
https://github.com/ONSdigital/eq-author-api/pull/109