### PR TITLE
Remove block title from published schema

### DIFF
--- a/src/eq_schema/Block.js
+++ b/src/eq_schema/Block.js
@@ -2,7 +2,6 @@ const Question = require("./Question");
 const RoutingRule = require("./RoutingRule");
 const RoutingDestination = require("./RoutingDestination");
 const { get, isNil, remove, isEmpty } = require("lodash");
-const { getInnerHTML } = require("../utils/HTMLUtils");
 const { flow, getOr, last, map, some } = require("lodash/fp");
 
 const pageTypeMappings = {
@@ -23,9 +22,8 @@ const isLastPageInSection = (page, ctx) =>
   )(ctx);
 
 class Block {
-  constructor(title, page, groupId, ctx) {
+  constructor(page, groupId, ctx) {
     this.id = `block${page.id}`;
-    this.title = getInnerHTML(title);
     this.type = this.convertPageType(page.pageType);
     this.questions = this.buildQuestions(page);
 

--- a/src/eq_schema/Block.test.js
+++ b/src/eq_schema/Block.test.js
@@ -8,7 +8,6 @@ describe("Block", () => {
     Object.assign(
       {
         id: 1,
-        title: "Question 1",
         pageType: "Question",
         type: "General",
         answers: []
@@ -17,33 +16,23 @@ describe("Block", () => {
     );
 
   it("should build valid runner Block from Author page", () => {
-    const block = new Block("section title", createBlockJSON(), ctx);
+    const block = new Block(createBlockJSON(), ctx);
 
     expect(block).toMatchObject({
       id: "block1",
-      title: "section title",
       questions: [expect.any(Question)]
     });
   });
 
-  it("should handle HTML values", () => {
-    const block = new Block(
-      "<p>section <em>title</em>",
-      createBlockJSON(),
-      ctx
-    );
+  it("should not have a title", () => {
+    const block = new Block(createBlockJSON(), ctx);
 
-    expect(block).toMatchObject({
-      id: "block1",
-      title: "section <em>title</em>",
-      questions: [expect.any(Question)]
-    });
+    expect(block.title).toBeUndefined();
   });
 
   describe("conversion of page types", () => {
     it("should convert QuestionPage to Questionnaire", () => {
       const block = new Block(
-        "section title",
         createBlockJSON({ pageType: "QuestionPage" }),
         ctx
       );
@@ -53,7 +42,6 @@ describe("Block", () => {
 
     it("should convert InterstitialPage to Interstitial", () => {
       const block = new Block(
-        "section title",
         createBlockJSON({ pageType: "InterstitialPage" }),
         ctx
       );

--- a/src/eq_schema/Group.js
+++ b/src/eq_schema/Group.js
@@ -7,7 +7,7 @@ class Group {
   constructor(id, title, pages, ctx) {
     this.id = `group${id}`;
     this.title = getInnerHTML(title);
-    this.blocks = this.buildBlocks(this.title, pages, id, ctx);
+    this.blocks = this.buildBlocks(pages, id, ctx);
 
     if (!isEmpty(ctx.routingGotos)) {
       this.filterContext(this.id, ctx);
@@ -34,8 +34,8 @@ class Group {
     );
   }
 
-  buildBlocks(title, pages, groupId, ctx) {
-    return pages.map(page => new Block(title, page, groupId, ctx));
+  buildBlocks(pages, groupId, ctx) {
+    return pages.map(page => new Block(page, groupId, ctx));
   }
 }
 

--- a/src/eq_schema/RoutingRule.test.js
+++ b/src/eq_schema/RoutingRule.test.js
@@ -150,14 +150,12 @@ describe("Rule", () => {
 
   it("should build valid runner routing to next page", () => {
     const block = new Block(
-      "section title",
       createRuleJSON(nextPageGoto, basicRadioCondition),
       "1",
       ctx
     );
     expect(block).toMatchObject({
       id: "block1",
-      title: "section title",
       questions: [expect.any(Question)],
       // eslint-disable-next-line camelcase
       routing_rules: [
@@ -178,14 +176,12 @@ describe("Rule", () => {
 
   it("should build valid runner routing to the End of Questionnaire", () => {
     const block = new Block(
-      "section title",
       createRuleJSON(endQuestionnaireGoto, basicRadioCondition),
       "1",
       ctx
     );
     expect(block).toMatchObject({
       id: "block1",
-      title: "section title",
       questions: [expect.any(Question)],
       // eslint-disable-next-line camelcase
       routing_rules: [
@@ -206,7 +202,6 @@ describe("Rule", () => {
 
   it("should build valid runner routing with 'other' answers", () => {
     const block = new Block(
-      "section title",
       createRuleJSON(nextPageGoto, otherCondition),
       "1",
       ctx
@@ -214,7 +209,6 @@ describe("Rule", () => {
 
     expect(block).toMatchObject({
       id: "block1",
-      title: "section title",
       questions: [expect.any(Question)],
       // eslint-disable-next-line camelcase
       routing_rules: [
@@ -238,11 +232,10 @@ describe("Rule", () => {
 
     const multiRules = createRuleJSON(absoluteSectionGoto, twoConditions);
 
-    const block = new Block("section title", multiRules, "1", ctx);
+    const block = new Block(multiRules, "1", ctx);
 
     expect(block).toMatchObject({
       id: "block1",
-      title: "section title",
       questions: [expect.any(Question)],
       // eslint-disable-next-line camelcase
       routing_rules: [
@@ -269,7 +262,6 @@ describe("Rule", () => {
   it("should add routing rule to ctx for out of section routing", () => {
     /* eslint-disable-next-line no-new */
     new Block(
-      "section title",
       createRuleJSON(endQuestionnaireGoto, basicRadioCondition),
       "1",
       ctx


### PR DESCRIPTION
### What is the context of this PR?
Removed block titles. Groups no longer pass title variables down to blocks. Tests updated to reflect this.

### How to review 
Review code and preview survey to make sure titles do not show up for blocks but section titles still show in right hand navigation.
