### PR TITLE
Fix issue unable to pipe currency answers.

### DIFF
--- a/src/eq_schema/Question.js
+++ b/src/eq_schema/Question.js
@@ -1,5 +1,5 @@
 const Answer = require("./Answer");
-const { getInnerHTML, parseGuidance } = require("../utils/HTMLUtils");
+const { parseGuidance, getInnerHTMLWithPiping } = require("../utils/HTMLUtils");
 const { find, get, flow, flatten, isNil, assign } = require("lodash/fp");
 const convertPipes = require("../utils/convertPipes");
 
@@ -11,7 +11,7 @@ const findDateRange = flow(
 const processPipedText = ctx =>
   flow(
     convertPipes(ctx),
-    getInnerHTML
+    getInnerHTMLWithPiping
   );
 const processGuidance = ctx =>
   flow(

--- a/src/eq_schema/Question.test.js
+++ b/src/eq_schema/Question.test.js
@@ -208,7 +208,7 @@ describe("Question", () => {
         createContext()
       );
 
-      expect(question.title).toEqual("{{answers.answer123}}");
+      expect(question.title).toEqual("{{ answers['answer123'] }}");
     });
 
     it("should handle piped values in guidance", () => {
@@ -220,7 +220,7 @@ describe("Question", () => {
       );
 
       expect(question.guidance.content[0]).toEqual({
-        title: "{{metadata.my_metadata}}"
+        title: "{{ metadata['my_metadata'] }}"
       });
     });
 
@@ -232,7 +232,7 @@ describe("Question", () => {
         createContext()
       );
 
-      expect(question.description).toEqual("{{answers.answer123}}");
+      expect(question.description).toEqual("{{ answers['answer123'] }}");
     });
   });
 });

--- a/src/utils/HTMLUtils.js
+++ b/src/utils/HTMLUtils.js
@@ -1,17 +1,31 @@
 const cheerio = require("cheerio");
 
+const { replace } = require("lodash/fp");
+
 const isPlainText = elem => typeof elem === "string" && !elem.startsWith("<");
 
 const getInnerHTML = elem => (isPlainText(elem) ? elem : cheerio(elem).html());
 
+const unescapePiping = value =>
+  replace(
+    /{{([^}}]+)}}/g,
+    (_, match) => `{{${replace(/&apos;/g, "'", match)}}}`,
+    value
+  );
+
+const getInnerHTMLWithPiping = elem => unescapePiping(getInnerHTML(elem));
+
 const getText = elem => (isPlainText(elem) ? elem : cheerio(elem).text());
 
-const description = elem => ({ description: getInnerHTML(elem) });
+const description = elem => ({ description: getInnerHTMLWithPiping(elem) });
 
-const title = elem => ({ title: getInnerHTML(elem) });
+const title = elem => ({ title: getInnerHTMLWithPiping(elem) });
 
 const list = elem => ({
-  list: cheerio(elem).find("li").map((i, li) => getInnerHTML(li)).toArray()
+  list: cheerio(elem)
+    .find("li")
+    .map((i, li) => getInnerHTMLWithPiping(li))
+    .toArray()
 });
 
 const mapElementToObject = elem => {
@@ -41,5 +55,7 @@ const parseGuidance = html => {
 module.exports = {
   getInnerHTML,
   getText,
-  parseGuidance
+  parseGuidance,
+  getInnerHTMLWithPiping,
+  unescapePiping
 };

--- a/src/utils/convertPipes.test.js
+++ b/src/utils/convertPipes.test.js
@@ -41,7 +41,7 @@ describe("convertPipes", () => {
     it("should convert relevant elements to pipe format", () => {
       const html = createPipe();
       expect(convertPipes(createContext())(html)).toEqual(
-        "{{answers.answer123}}"
+        "{{ answers['answer123'] }}"
       );
     });
 
@@ -51,7 +51,7 @@ describe("convertPipes", () => {
       const html = `${pipe1}${pipe2}`;
 
       expect(convertPipes(createContext())(html)).toEqual(
-        "{{answers.answer123}}{{answers.answer456}}"
+        "{{ answers['answer123'] }}{{ answers['answer456'] }}"
       );
     });
 
@@ -61,7 +61,7 @@ describe("convertPipes", () => {
       const html = `hello ${pipe1}${pipe2} world`;
 
       expect(convertPipes(createContext())(html)).toEqual(
-        "hello {{answers.answer123}}{{answers.answer456}} world"
+        "hello {{ answers['answer123'] }}{{ answers['answer456'] }} world"
       );
     });
 
@@ -69,21 +69,21 @@ describe("convertPipes", () => {
       it("should format Date answers with `format_date`", () => {
         const html = createPipe({ id: "123", type: "Date" });
         expect(convertPipes(createContext())(html)).toEqual(
-          "{{answers.answer123|format_date}}"
+          "{{ answers['answer123'] | format_date }}"
         );
       });
 
       it("should format Currency answers with `format_currency`", () => {
         const html = createPipe({ id: "123", type: "Currency" });
         expect(convertPipes(createContext())(html)).toEqual(
-          "{{answers.answer123|format_currency}}"
+          "{{ format_currency(answers['answer123'], 'GBP') }}"
         );
       });
 
       it("should format Number answers with `format_number`", () => {
         const html = createPipe({ id: "123", type: "Number" });
         expect(convertPipes(createContext())(html)).toEqual(
-          "{{answers.answer123|format_number}}"
+          "{{ answers['answer123'] | format_number }}"
         );
       });
     });
@@ -94,7 +94,7 @@ describe("convertPipes", () => {
       const html = createPipe({ pipeType: "metadata" });
       const metadata = [{ id: "123", key: "my_metadata", type: "Text" }];
       expect(convertPipes(createContext(metadata))(html)).toEqual(
-        "{{metadata.my_metadata}}"
+        "{{ metadata['my_metadata'] }}"
       );
     });
 
@@ -109,7 +109,7 @@ describe("convertPipes", () => {
         const html = createPipe({ pipeType: "metadata" });
         const metadata = [{ id: "123", key: "my_metadata", type: "Date" }];
         expect(convertPipes(createContext(metadata))(html)).toEqual(
-          "{{metadata.my_metadata|format_date}}"
+          "{{ metadata['my_metadata'] | format_date }}"
         );
       });
     });


### PR DESCRIPTION
### What is the context of this PR?
There is an issue piping currency answers. It turns out that survey runner no longer support the `format_currency` Jinja filter. Instead, the recommended approach is to use the `format_currency(value, unit)` context function.

This PR makes changes to Publisher so that it uses the new approach to formatting currency answers.

It also changes more generally how piped values are represented in the resulting schema.

Prior to this change answers and metadata were piped like this:

`{{answers.answer123}}` and `{{metadata.ru_ref}}`.

This PR changes the format to look like this:

`{{ answers['answer123'] }}` and `{{ metadata['ru_ref'] }}` as per recommendations made by the runner team.

To fully realise this change, I also had to ensure that the single quotes in piped values are not escaped in the resulting rich text HTML.

### How to review

- Test piping thoroughly to ensure that I haven't broken anything in the process.
- It should be possible to pipe basic answer types as before.
- It should also be possible now to pipe currency answers.
- It should be possible to pipe metadata.
- Filters applied appropriately to currency answer so that it appears as a currency value when previewed in survey runner.
