### PR TITLE
651 - Max value validation against previous answers

### DIFF
--- a/src/api/queries.js
+++ b/src/api/queries.js
@@ -21,6 +21,10 @@ exports.getQuestionnaire = `
             inclusive
             enabled
             custom
+            entityType
+            previousAnswer {
+              id
+            }
           }
         }
         ...on DateValidation{

--- a/src/eq_schema/Answer.js
+++ b/src/eq_schema/Answer.js
@@ -77,17 +77,37 @@ class Answer {
   }
 
   buildNumberValidation(validationRule, validationType) {
-    const { enabled, custom } = validationRule;
-    if (!enabled || isNil(custom)) {
+    const { enabled } = validationRule;
+    if (!enabled) {
       return;
     }
 
-    Object.assign(this, {
-      [validationType]: {
-        value: custom,
-        exclusive: !validationRule.inclusive
+    const comparator = this.buildNumberComparator(validationRule);
+    if (isNil(comparator)) {
+      return;
+    }
+
+    this[validationType] = {
+      ...comparator,
+      exclusive: !validationRule.inclusive
+    };
+  }
+
+  buildNumberComparator(validationRule) {
+    const { entityType = "Custom", custom, previousAnswer } = validationRule;
+    if (entityType === "Custom") {
+      if (isNil(custom)) {
+        return;
       }
-    });
+      return { value: custom };
+    }
+    if (entityType === "PreviousAnswer") {
+      if (isNil(previousAnswer)) {
+        return;
+      }
+      return { answer_id: `answer${previousAnswer.id}` };
+    }
+    return;
   }
 
   buildDateValidation(validationRule, validationType) {


### PR DESCRIPTION
### What is the context of this PR?
Implement the changes to publish max value validation against previous answers.

### How to review 
1. Ensure tests pass.
1. Ensure that you can publish a schema with two number answers where the second answer is reliant on the first. Then check that answer given in the first is used to validate the second.

### Dependencies
- [x] - https://github.com/ONSdigital/eq-author-api/pull/152