### PR TITLE
Temporary fix for broken preview with mutually exclusive.

### DIFF
--- a/src/eq_schema/Answer.js
+++ b/src/eq_schema/Answer.js
@@ -55,7 +55,7 @@ class Answer {
     }
 
     if (!isNil(answer.mutuallyExclusiveOption)) {
-      this.type = "MutuallyExclusiveCheckbox";
+      this.type = "Checkbox";
       this.options = this.options.concat(
         this.buildOption(answer.mutuallyExclusiveOption)
       );

--- a/src/eq_schema/Answer.test.js
+++ b/src/eq_schema/Answer.test.js
@@ -406,7 +406,7 @@ describe("Answer", () => {
         })
       );
 
-      expect(answer.type).toEqual("MutuallyExclusiveCheckbox");
+      expect(answer.type).toEqual("Checkbox");
 
       expect(last(answer.options)).toEqual({
         label: "Option three",


### PR DESCRIPTION
### What is the context of this PR?
This change is a temporary workaround to fix the broken preview for questionnaires containing mutually exclusive checkbox options.

Previewing questionnaires that contain mutually exclusive checkbox answers broke as a result of a recent change to schema validator. The schema for mutually exclusive answers has changed and is now incompatible with publisher.

This PR is a temporary fix until a further change can be made to publisher to adhere to the new schema.

Following this change it should be possible to preview questionnaires containing mutually exclusive options once again, but the mutually exclusive checkbox option will appear in line with all of the other options and will not stand alone in its own OR option.

### How to review 

- Checkout master
- Create a questionnaire containing a Checkbox answer with a mutually exclusive option "Add OR option"
- Attempt to preview (it should fail)
- Checkout this branch
- Attempt to preview (it should succeed but mutually exclusive option will appear next to all other checkbox options).
