### PR TITLE
Add previous answer to earliest and latest date validation

### DIFF
--- a/src/api/queries.js
+++ b/src/api/queries.js
@@ -37,6 +37,10 @@ exports.getQuestionnaire = `
               unit
             }
             relativePosition
+            entityType
+            previousAnswer {
+              id
+            }
           }
           latestDate{
             id
@@ -47,6 +51,10 @@ exports.getQuestionnaire = `
               unit
             }
             relativePosition
+            entityType
+            previousAnswer {
+              id
+            }
           }
         }
       }

--- a/src/eq_schema/Answer.js
+++ b/src/eq_schema/Answer.js
@@ -82,7 +82,8 @@ class Answer {
       return;
     }
 
-    const comparator = this.buildNumberComparator(validationRule);
+    const comparator = this.buildComparator(validationRule);
+
     if (isNil(comparator)) {
       return;
     }
@@ -93,7 +94,7 @@ class Answer {
     };
   }
 
-  buildNumberComparator(validationRule) {
+  buildComparator(validationRule) {
     const { entityType = "Custom", custom, previousAnswer } = validationRule;
     if (entityType === "Custom") {
       if (isNil(custom)) {
@@ -111,8 +112,14 @@ class Answer {
   }
 
   buildDateValidation(validationRule, validationType) {
-    const { enabled, custom } = validationRule;
-    if (!enabled || isNil(custom)) {
+    const { enabled } = validationRule;
+    if (!enabled) {
+      return;
+    }
+
+    const comparator = this.buildComparator(validationRule);
+
+    if (isNil(comparator)) {
       return;
     }
 
@@ -123,7 +130,7 @@ class Answer {
 
     Object.assign(this, {
       [validationType]: {
-        value: custom,
+        ...comparator,
         offset_by: {
           [offsetUnit]: offsetValue
         }

--- a/src/eq_schema/Answer.test.js
+++ b/src/eq_schema/Answer.test.js
@@ -221,6 +221,63 @@ describe("Answer", () => {
         expect(answer.minimum.value).toEqual("2017-02-17");
       });
 
+      it("should add earliest date previous answer", () => {
+        const answer = new Answer(
+          createAnswerJSON({
+            type: "Date",
+            validation: {
+              earliestDate: {
+                id: "1",
+                enabled: true,
+                entityType: "PreviousAnswer",
+                custom: null,
+                previousAnswer: {
+                  id: "3"
+                },
+                offset: {
+                  value: 4,
+                  unit: "Days"
+                },
+                relativePosition: "Before"
+              },
+              latestDate: {
+                enabled: false
+              }
+            }
+          })
+        );
+
+        expect(answer.minimum).toMatchObject({
+          answer_id: "answer3"
+        });
+      });
+
+      it("should drop validation that has an entity type of PreviousAnswer but no answer", () => {
+        const answer = new Answer(
+          createAnswerJSON({
+            type: "Date",
+            validation: {
+              earliestDate: {
+                id: "1",
+                enabled: true,
+                entityType: "PreviousAnswer",
+                custom: null,
+                previousAnswer: null,
+                offset: {
+                  value: 4,
+                  unit: "Days"
+                },
+                relativePosition: "Before"
+              },
+              latestDate: {
+                enabled: false
+              }
+            }
+          })
+        );
+        expect(answer.minimum).toBeUndefined();
+      });
+
       it("should add a positive days offset", () => {
         authorDateAnswer.validation.earliestDate.relativePosition = "After";
         authorDateAnswer.validation.earliestDate.offset = {
@@ -285,6 +342,63 @@ describe("Answer", () => {
         authorDateAnswer.validation.latestDate.custom = "2017-02-17";
         const answer = new Answer(createAnswerJSON(authorDateAnswer));
         expect(answer.maximum.value).toEqual("2017-02-17");
+      });
+
+      it("should add latest date previous answer", () => {
+        const answer = new Answer(
+          createAnswerJSON({
+            type: "Date",
+            validation: {
+              latestDate: {
+                id: "1",
+                enabled: true,
+                entityType: "PreviousAnswer",
+                custom: null,
+                previousAnswer: {
+                  id: "3"
+                },
+                offset: {
+                  value: 4,
+                  unit: "Days"
+                },
+                relativePosition: "Before"
+              },
+              earliestDate: {
+                enabled: false
+              }
+            }
+          })
+        );
+
+        expect(answer.maximum).toMatchObject({
+          answer_id: "answer3"
+        });
+      });
+
+      it("should drop validation that has an entity type of PreviousAnswer but no answer", () => {
+        const answer = new Answer(
+          createAnswerJSON({
+            type: "Date",
+            validation: {
+              latestDate: {
+                id: "1",
+                enabled: true,
+                entityType: "PreviousAnswer",
+                custom: null,
+                previousAnswer: null,
+                offset: {
+                  value: 4,
+                  unit: "Days"
+                },
+                relativePosition: "Before"
+              },
+              earliestDate: {
+                enabled: false
+              }
+            }
+          })
+        );
+        expect(answer.maximum).toBeUndefined();
       });
 
       it("should add a positive days offset", () => {


### PR DESCRIPTION
### What is the context of this PR?
- Adds the previous answer for earliest and latest date validation

### How to review 
- Run tests