### PR TITLE
Add metadata to earliest and latest date validation

### DIFF
--- a/src/api/queries.js
+++ b/src/api/queries.js
@@ -41,6 +41,9 @@ exports.getQuestionnaire = `
             previousAnswer {
               id
             }
+            metadata {
+              key
+            }
           }
           latestDate{
             id
@@ -54,6 +57,9 @@ exports.getQuestionnaire = `
             entityType
             previousAnswer {
               id
+            }
+            metadata {
+              key
             }
           }
         }

--- a/src/eq_schema/Answer.js
+++ b/src/eq_schema/Answer.js
@@ -88,7 +88,12 @@ class Answer {
   }
 
   buildComparator(validationRule) {
-    const { entityType = "Custom", custom, previousAnswer } = validationRule;
+    const {
+      entityType = "Custom",
+      custom,
+      previousAnswer,
+      metadata
+    } = validationRule;
     if (entityType === "Custom") {
       if (isNil(custom)) {
         return;
@@ -100,6 +105,13 @@ class Answer {
         return;
       }
       return { answer_id: `answer${previousAnswer.id}` };
+    }
+
+    if (entityType === "Metadata") {
+      if (isNil(metadata)) {
+        return;
+      }
+      return { meta: metadata.key };
     }
     return;
   }

--- a/src/eq_schema/Answer.test.js
+++ b/src/eq_schema/Answer.test.js
@@ -251,6 +251,38 @@ describe("Answer", () => {
         });
       });
 
+      it("should add earliest date metadata", () => {
+        const answer = new Answer(
+          createAnswerJSON({
+            type: "Date",
+            validation: {
+              earliestDate: {
+                id: "1",
+                enabled: true,
+                entityType: "Metadata",
+                custom: null,
+                previousAnswer: null,
+                metadata: {
+                  key: "test_ref"
+                },
+                offset: {
+                  value: 4,
+                  unit: "Days"
+                },
+                relativePosition: "Before"
+              },
+              latestDate: {
+                enabled: false
+              }
+            }
+          })
+        );
+
+        expect(answer.minimum).toMatchObject({
+          meta: "test_ref"
+        });
+      });
+
       it("should drop validation that has an entity type of PreviousAnswer but no answer", () => {
         const answer = new Answer(
           createAnswerJSON({
@@ -262,6 +294,33 @@ describe("Answer", () => {
                 entityType: "PreviousAnswer",
                 custom: null,
                 previousAnswer: null,
+                offset: {
+                  value: 4,
+                  unit: "Days"
+                },
+                relativePosition: "Before"
+              },
+              latestDate: {
+                enabled: false
+              }
+            }
+          })
+        );
+        expect(answer.minimum).toBeUndefined();
+      });
+
+      it("should drop validation that has an entity type of Metadata but no metadata", () => {
+        const answer = new Answer(
+          createAnswerJSON({
+            type: "Date",
+            validation: {
+              earliestDate: {
+                id: "1",
+                enabled: true,
+                entityType: "Metadata",
+                custom: null,
+                previousAnswer: null,
+                metadata: null,
                 offset: {
                   value: 4,
                   unit: "Days"
@@ -374,6 +433,38 @@ describe("Answer", () => {
         });
       });
 
+      it("should add latest date metadata", () => {
+        const answer = new Answer(
+          createAnswerJSON({
+            type: "Date",
+            validation: {
+              latestDate: {
+                id: "1",
+                enabled: true,
+                entityType: "Metadata",
+                custom: null,
+                previousAnswer: null,
+                metadata: {
+                  key: "test_ref"
+                },
+                offset: {
+                  value: 4,
+                  unit: "Days"
+                },
+                relativePosition: "Before"
+              },
+              earliestDate: {
+                enabled: false
+              }
+            }
+          })
+        );
+
+        expect(answer.maximum).toMatchObject({
+          meta: "test_ref"
+        });
+      });
+
       it("should drop validation that has an entity type of PreviousAnswer but no answer", () => {
         const answer = new Answer(
           createAnswerJSON({
@@ -385,6 +476,33 @@ describe("Answer", () => {
                 entityType: "PreviousAnswer",
                 custom: null,
                 previousAnswer: null,
+                offset: {
+                  value: 4,
+                  unit: "Days"
+                },
+                relativePosition: "Before"
+              },
+              earliestDate: {
+                enabled: false
+              }
+            }
+          })
+        );
+        expect(answer.maximum).toBeUndefined();
+      });
+
+      it("should drop validation that has an entity type of Metadata but no metadata", () => {
+        const answer = new Answer(
+          createAnswerJSON({
+            type: "Date",
+            validation: {
+              latestDate: {
+                id: "1",
+                enabled: true,
+                entityType: "Metadata",
+                custom: null,
+                previousAnswer: null,
+                metadata: null,
                 offset: {
                   value: 4,
                   unit: "Days"


### PR DESCRIPTION
### What is the context of this PR?
- Adds the metadata for earliest and latest date validation

### How to review 
- Run tests

### Dependencies
- [x] https://github.com/ONSdigital/eq-author-api/pull/166