### PR TITLE
Remove deprecated field reference from publisher.

### DIFF
--- a/src/api/queries.js
+++ b/src/api/queries.js
@@ -123,7 +123,6 @@ exports.getQuestionnaire = `
       sections {
         id
         title
-        description
         pages {
           ... on QuestionPage {
             id


### PR DESCRIPTION
### What is the context of this PR?
There's a reference to section description in the query that gets executed by publisher that needs to be removed before https://github.com/ONSdigital/eq-author-api/pull/145 gets merged.

### How to review 
Change looks okay. All tests and checks should pass.
