### PR TITLE
Added inclusive number options to routing

### DIFF
--- a/src/eq_schema/builders/routingcondition/NumberRoutingCondition.js
+++ b/src/eq_schema/builders/routingcondition/NumberRoutingCondition.js
@@ -2,7 +2,9 @@ const comparatorLookup = {
   Equal: "equals",
   NotEqual: "not equals",
   GreaterThan: "greater than",
-  LessThan: "less than"
+  GreaterOrEqual: "greater than or equal to",
+  LessThan: "less than",
+  LessOrEqual: "less than or equal to"
 };
 
 class NumberRoutingCondition {


### PR DESCRIPTION
### What is the context of this PR?
Due to Runner limitations we were not able to include the inclusive comparators on the first pass of routing based on a number. This has since been resolved so this PR adds that functionality. 

### How to review 
Tests pass and you are able to publish a survey with an inclusive comparator in the routing conditions.