### PR TITLE
Trim whitespace in schema values

### DIFF
--- a/src/middleware/respondWithData.js
+++ b/src/middleware/respondWithData.js
@@ -1,3 +1,8 @@
 module.exports = function respondWithData(req, res) {
-  res.json(res.locals.questionnaire);
+  var questionnaire = res.locals.questionnaire;
+  var trimmedQuestionnaire = JSON.parse(
+    JSON.stringify(questionnaire).replace(/"\s+|\s+"/g, '"')
+  );
+
+  res.json(trimmedQuestionnaire);
 };

--- a/src/middleware/respondWithData.test.js
+++ b/src/middleware/respondWithData.test.js
@@ -3,10 +3,26 @@ const respondWithData = require("./respondWithData");
 describe("fetchData", () => {
   let res, req;
 
+  let trimmedQuestionnaire = {
+    id: "123",
+    sections: [
+      {
+        title: "Whitespaced"
+      }
+    ]
+  };
+
   beforeEach(() => {
     res = {
       locals: {
-        questionnaire: { id: "123" }
+        questionnaire: {
+          id: "123   ",
+          sections: [
+            {
+              title: "   Whitespaced   "
+            }
+          ]
+        }
       },
       json: jest.fn()
     };
@@ -16,6 +32,11 @@ describe("fetchData", () => {
 
   it("respond with local data from response", () => {
     respondWithData(req, res);
-    expect(res.json).toHaveBeenCalledWith(res.locals.questionnaire);
+    expect(res.json).toHaveBeenCalledWith(trimmedQuestionnaire);
+  });
+
+  it("respond with trimmed data values", () => {
+    respondWithData(req, res);
+    expect(res.json).toHaveBeenCalledWith(trimmedQuestionnaire);
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
When an author adds whitespace at the end of values accidentally. This is passed to runner and displayed to respondents.

This PR trims whitespace from all values within the generated schema.

### How to review 
Add whitespace at the beginning and end of some text in author. 
Publish the schema and observe that the whitespace has been removed.
